### PR TITLE
allow access to spheroid parameter

### DIFF
--- a/addons/jts/src/test/scala/com/github/tminglei/slickpg/PgPostGISSupportTest.scala
+++ b/addons/jts/src/test/scala/com/github/tminglei/slickpg/PgPostGISSupportTest.scala
@@ -165,6 +165,16 @@ class PgPostGISSupportTest {
 
       val q14 = GeomTests.filter(r => { r.id === bean.id.bind && (point.bind |>> r.geom) }).map(r => r)
       assertEquals(bean, q14.first())
+
+      val q15 = {
+        val latLongPoint = makePoint(point2.getX, point2.getY).setSRID(4326)
+        val distanceQuery = PointTests.filter(_.id === pbean1.id.bind)
+        val distance = distanceQuery.map(_.point.setSRID(4326).distanceSphere(latLongPoint)).first
+        distanceQuery.map { p =>
+          ( p.point.setSRID(4326).dWithin(latLongPoint, distance * 1.01, true),
+            p.point.setSRID(4326).dWithin(latLongPoint, distance * 0.99, true)) }.first
+      }
+      assertEquals((true, false), q15)
     }
   }
 

--- a/core/src/main/scala/com/github/tminglei/slickpg/geom/PgPostGISExtensions.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/geom/PgPostGISExtensions.scala
@@ -443,6 +443,10 @@ trait PgPostGISExtensions extends JdbcTypesComponent { driver: PostgresDriver =>
     def dWithin[P2, R](geom: Column[P2], distance: Column[Double])(implicit om: o#to[Boolean, R]) = {
         om.column(GeomLibrary.DWithin, n, geom.toNode, distance.toNode)
       }
+    def dWithin[P2, R](geom: Column[P2], distance: Column[Double], spheroid: Column[Boolean])(implicit om: o#to[Boolean, R]) = {
+      om.column(GeomLibrary.DWithin, n, geom.toNode, distance.toNode, spheroid.toNode)
+      }
+
     def dFullyWithin[P2, R](geom: Column[P2], distance: Column[Double])(implicit om: o#to[Boolean, R]) = {
         om.column(GeomLibrary.DFullyWithin, n, geom.toNode, distance.toNode)
       }


### PR DESCRIPTION
Hi Minglei,

I have another change. I wanted to access the spheroid parameter to return the distance in meters between two SRID 4326 coordinates.

I've implemented in such a way that if you don't provide the spheroid parameter, it will not provide any value to postgres, thus not interfering with Postgres's default behavior of auto-enabling spheroid if a geography type is provided.

The tests do not conform so closely with your pattern, but I tried to make it match as more than not.

Thank you!
