### PR TITLE
Update plugins.sbt : correct version of sbt-plugin

### DIFF
--- a/examples/play-slick-sample/project/plugins.sbt
+++ b/examples/play-slick-sample/project/plugins.sbt
@@ -7,4 +7,4 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.0"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.2.0"))


### PR DESCRIPTION
Fixing this issue:

```
[warn]  Note: Some unresolved dependencies have extra attributes.  Check that these dependencies exist with the requested attributes.
[warn]      com.typesafe.play:sbt-plugin:2.0 (sbtVersion=0.13, scalaVersion=2.10)
[warn] 
sbt.ResolveException: unresolved dependency: com.typesafe.play#sbt-plugin;2.0: not found
    at sbt.IvyActions$.sbt$IvyActions$$resolve(IvyActions.scala:213)

```
