### PR TITLE
Avoid using a SimpleDateFormat for parsing java.sql.{Date, Time, Timestamp}

### DIFF
--- a/core/src/main/scala/com/github/tminglei/slickpg/utils/TypeConverters.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/utils/TypeConverters.scala
@@ -60,21 +60,6 @@ object TypeConverters extends Logging {
   object Util {
     import PGObjectTokenizer.PGElements._
     
-    private[this] val tsFormatterLocal = new ThreadLocal[SimpleDateFormat](){
-      override def initialValue() = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-    }
-    def tsFormatter() = tsFormatterLocal.get()
-
-    private[this] val dateFormatterLocal = new ThreadLocal[SimpleDateFormat](){
-        override def initialValue() = new SimpleDateFormat("yyyy-MM-dd")
-    }
-    def dateFormatter() = dateFormatterLocal.get()
-
-    private[this] val timeFormatterLocal = new ThreadLocal[SimpleDateFormat](){
-        override def initialValue() = new SimpleDateFormat("HH:mm:ss")
-    }
-    def timeFormatter() = timeFormatterLocal.get()
-
     private def pgBoolAdjust(s: String): String =
       Option(s).map(_.toLowerCase) match {
         case Some("t")  => "true"
@@ -92,12 +77,12 @@ object TypeConverters extends Logging {
       register((v: String) => v.toByte)
       register((v: String) => UUID.fromString(v))
       // register date/time converters
-      register((v: String) => new Date(dateFormatter.parse(v).getTime))
-      register((v: String) => new Time(timeFormatter.parse(v).getTime))
-      register((v: String) => new Timestamp(tsFormatter.parse(v).getTime))
-      register((v: Date) => dateFormatter.format(v))
-      register((v: Time) => timeFormatter.format(v))
-      register((v: Timestamp) => tsFormatter.format(v))
+      register((v: String) => Date.valueOf(v))
+      register((v: String) => Time.valueOf(v))
+      register((v: String) => Timestamp.valueOf(v))
+      register((v: Date) => v.toString)
+      register((v: Time) => v.toString)
+      register((v: Timestamp) => v.toString)
       true
     }
 

--- a/src/main/scala/com/github/tminglei/slickpg/PgRangeSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgRangeSupport.scala
@@ -9,8 +9,8 @@ trait PgRangeSupport extends range.PgRangeExtensions with utils.PgCommonJdbcType
 
   type RANGEType[T] = Range[T]
 
-  private def toTimestamp(str: String) = new Timestamp(tsFormatter.parse(str).getTime)
-  private def toSQLDate(str: String) = new Date(dateFormatter.parse(str).getTime)
+  private def toTimestamp(str: String) = Timestamp.valueOf(str)
+  private def toSQLDate(str: String) = Date.valueOf(str)
 
   trait RangeImplicits {
     implicit val intRangeTypeMapper = new GenericJdbcType[Range[Int]]("int4range", mkRangeFn(_.toInt))
@@ -31,17 +31,6 @@ trait PgRangeSupport extends range.PgRangeExtensions with utils.PgCommonJdbcType
 }
 
 object PgRangeSupportUtils {
-  import java.text.SimpleDateFormat
-
-  private[this] val tsFormatterLocal = new ThreadLocal[SimpleDateFormat](){
-    override def initialValue() = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-  }
-  def tsFormatter() = tsFormatterLocal.get()
-
-  private[this] val dateFormatterLocal = new ThreadLocal[SimpleDateFormat](){
-    override def initialValue() = new SimpleDateFormat("yyyy-MM-dd")
-  }
-  def dateFormatter() = dateFormatterLocal.get()
 
   // regular expr matchers to range string
   val `[_,_)Range`  = """\["?([^,"]*)"?,[ ]*"?([^,"]*)"?\)""".r   // matches: [_,_)


### PR DESCRIPTION
Killing complexity introduced in my last commit. 
This is much faster with a reduced memory footprint.
