### PR TITLE
cross-compile for scala 2.11/2.10

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,8 @@ object SlickPgBuild extends Build {
     organizationName := "slick-pg",
     organization := "com.github.tminglei",
 
-    scalaVersion := "2.10.3",
+    scalaVersion := "2.10.4",
+    crossScalaVersions := Seq("2.11.1", "2.10.4"),
     scalacOptions ++= Seq("-deprecation", "-feature",
       "-language:implicitConversions",
       "-language:reflectiveCalls",
@@ -57,19 +58,27 @@ object SlickPgBuild extends Build {
     s3region := com.amazonaws.services.s3.model.Region.US_West_2
   )
   
-  lazy val mainDependencies = Seq (
-    "org.scala-lang" % "scala-reflect" % "2.10.3",
-    "com.typesafe.slick" % "slick_2.10" % "2.1.0-SNAPSHOT",
-    "org.postgresql" % "postgresql" % "9.3-1100-jdbc41",
-    "junit" % "junit" % "4.11" % "test",
-    "com.novocode" % "junit-interface" % "0.10" % "test"
-  )
+  def mainDependencies(scalaVersion:String) = {
+    val extractedLibs = CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+        Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1")
+      case _ =>
+        Seq()
+    }
+    Seq (
+      "org.scala-lang" % "scala-reflect" % scalaVersion,
+      "com.typesafe.slick" %% "slick" % "2.1.0-SNAPSHOT",
+      "org.postgresql" % "postgresql" % "9.3-1100-jdbc41",
+      "junit" % "junit" % "4.11" % "test",
+      "com.novocode" % "junit-interface" % "0.10" % "test"
+    ) ++ extractedLibs
+  }
 
   lazy val coreSettings = Seq(
     name := "slick-pg_core",
     description := "Slick extensions for PostgreSQL - Core",
     version := "0.5.3",
-    libraryDependencies := mainDependencies
+    libraryDependencies := mainDependencies(scalaVersion.value)
   )
 
   lazy val slickPgSettings = Seq(
@@ -81,7 +90,7 @@ object SlickPgBuild extends Build {
     settings = Project.defaultSettings ++ commonSettings ++ slickPgSettings ++ Seq(
       name := "slick-pg",
       description := "Slick extensions for PostgreSQL",
-      libraryDependencies := mainDependencies
+      libraryDependencies := mainDependencies(scalaVersion.value)
     ) 
   ).dependsOn (slickPgCore)
    .aggregate (slickPgCore, slickPgJoda, slickPgJson4s, slickPgJts, slickPgPlayJson, slickPgSprayJson, slickPgThreeten, slickPgDate2)
@@ -93,7 +102,7 @@ object SlickPgBuild extends Build {
     settings = Project.defaultSettings ++ commonSettings ++ slickPgSettings ++ Seq(
       name := "slick-pg_joda-time",
       description := "Slick extensions for PostgreSQL - joda time module",
-      libraryDependencies := mainDependencies ++ Seq(
+      libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
         "joda-time" % "joda-time" % "2.3",
         "org.joda" % "joda-convert" % "1.5"
       )
@@ -104,10 +113,10 @@ object SlickPgBuild extends Build {
     settings = Project.defaultSettings ++ commonSettings ++ slickPgSettings ++ Seq(
       name := "slick-pg_json4s",
       description := "Slick extensions for PostgreSQL - json4s module",
-      libraryDependencies := mainDependencies ++ Seq(
-        "org.json4s" % "json4s-ast_2.10" % "3.2.6",
-        "org.json4s" % "json4s-core_2.10" % "3.2.6",
-        "org.json4s" % "json4s-native_2.10" % "3.2.6" % "test"
+      libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
+        "org.json4s" %% "json4s-ast" % "3.2.10",
+        "org.json4s" %% "json4s-core" % "3.2.10",
+        "org.json4s" %% "json4s-native" % "3.2.10" % "test"
       )
     )
   ) dependsOn (slickPgCore)
@@ -116,7 +125,7 @@ object SlickPgBuild extends Build {
     settings = Project.defaultSettings ++ commonSettings ++ slickPgSettings ++ Seq(
       name := "slick-pg_jts",
       description := "Slick extensions for PostgreSQL - jts module",
-      libraryDependencies := mainDependencies ++ Seq(
+      libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
         "com.vividsolutions" % "jts" % "1.13"
       )
     )
@@ -126,8 +135,8 @@ object SlickPgBuild extends Build {
     settings = Project.defaultSettings ++ commonSettings ++ slickPgSettings ++ Seq(
       name := "slick-pg_play-json",
       description := "Slick extensions for PostgreSQL - play-json module",
-      libraryDependencies := mainDependencies ++ Seq(
-        "com.typesafe.play" % "play-json_2.10" % "2.2.1"
+      libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
+        "com.typesafe.play" %% "play-json" % "2.3.0-RC2"
       )
     )
   ) dependsOn (slickPgCore)
@@ -136,8 +145,8 @@ object SlickPgBuild extends Build {
     settings = Project.defaultSettings ++ commonSettings ++ slickPgSettings ++ Seq(
       name := "slick-pg_spray-json",
       description := "Slick extensions for PostgreSQL - spray-json module",
-      libraryDependencies := mainDependencies ++ Seq(
-        "io.spray" %%  "spray-json" % "1.2.5"
+      libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
+        "io.spray" %%  "spray-json" % "1.2.6"
       )
     )
   ) dependsOn (slickPgCore)
@@ -146,7 +155,7 @@ object SlickPgBuild extends Build {
     settings = Project.defaultSettings ++ commonSettings ++ slickPgSettings ++ Seq(
       name := "slick-pg_threeten",
       description := "Slick extensions for PostgreSQL - threeten module",
-      libraryDependencies := mainDependencies ++ Seq(
+      libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
         "org.threeten" % "threetenbp" % "0.8.1"
       )
     )
@@ -156,7 +165,7 @@ object SlickPgBuild extends Build {
     settings = Project.defaultSettings ++ commonSettings ++ slickPgSettings ++ Seq(
       name := "slick-pg_date2",
       description := "Slick extensions for PostgreSQL - date2 module (jdk8 time)",
-      libraryDependencies := mainDependencies
+      libraryDependencies := mainDependencies(scalaVersion.value)
     )
   ) dependsOn (slickPgCore)
 


### PR DESCRIPTION
This updates libraries to versions with current 2.11 releases.

I am able to build slick-pt for both 2.10 and 2.11 with this patch, using +compile. However, I am using a custom build of slick, and was unable to test your UnaryAggFuncPartsBasic functions.
