### PR TITLE
bugfix: express timestamps as literal timestamps, not dates.

### DIFF
--- a/core/src/main/scala/com/github/tminglei/slickpg/date/PgDateJdbcTypes.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/date/PgDateJdbcTypes.scala
@@ -60,6 +60,6 @@ trait PgDateJdbcTypes extends JdbcTypesComponent { driver: PostgresDriver =>
 
     override def updateValue(v: TIMESTAMP, r: ResultSet, idx: Int): Unit = r.updateTimestamp(idx, fnToTimestamp(v))
 
-    override def valueToSQLLiteral(v: TIMESTAMP) = s"{d '${fnToTimestamp(v)}'}"
+    override def valueToSQLLiteral(v: TIMESTAMP) = s"{ts '${fnToTimestamp(v)}'}"
   }
 }


### PR DESCRIPTION
Sorry, I didn't write a test for this. If you want to wait, I will, but this regression is pretty serious and almost bit us. (fortunately, was caught by integration tests).

TIMESTAMPS were being truncated to dates due to the the wrong literal specification being used.

This patch fixes the bug for us and causes our integration tests to pass again.
