### PR TITLE
Static sql

### DIFF
--- a/core/src/main/scala/com/github/tminglei/slickpg/array/PgArrayJdbcTypes.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/array/PgArrayJdbcTypes.scala
@@ -2,7 +2,6 @@ package com.github.tminglei.slickpg
 package array
 
 import scala.reflect.ClassTag
-import java.util.{Map => JMap}
 import scala.slick.driver.{PostgresDriver, JdbcTypesComponent}
 import java.sql.{ResultSet, PreparedStatement}
 
@@ -44,7 +43,7 @@ trait PgArrayJdbcTypes extends JdbcTypesComponent { driver: PostgresDriver =>
       }
 
     //--
-    private def mkArray(v: List[T]): java.sql.Array = new SimpleArray(sqlBaseType, v, buildArrayStr)
+    private def mkArray(v: List[T]): java.sql.Array = utils.SimpleArrayUtils.mkArray(buildArrayStr)(sqlBaseType, v)
 
     protected def buildArrayStr(vList: List[Any]): String = utils.SimpleArrayUtils.mkString[Any](_.toString)(vList)
   }
@@ -78,34 +77,6 @@ trait PgArrayJdbcTypes extends JdbcTypesComponent { driver: PostgresDriver =>
     override def valueToSQLLiteral(vList: List[T]) = if(vList eq null) "NULL" else s"'${mkString(vList)}'"
 
     //--
-    private def mkArray(v: List[T]): java.sql.Array = new SimpleArray(sqlBaseType, v, mkString)
-  }
-
-  /** only used to transfer array data into driver/preparedStatement */
-  private class SimpleArray[T : ClassTag](sqlBaseTypeName: String, vList: List[T], mkString: (List[T] => String)) extends java.sql.Array {
-
-    def getBaseTypeName = sqlBaseTypeName.replaceFirst("^\"", "").replaceFirst("\"$", "")
-
-    def getBaseType = ???
-
-    def getArray = vList.toArray
-
-    def getArray(map: JMap[String, Class[_]]) = ???
-
-    def getArray(index: Long, count: Int) = ???
-
-    def getArray(index: Long, count: Int, map: JMap[String, Class[_]]) = ???
-
-    def getResultSet = ???
-
-    def getResultSet(map: JMap[String, Class[_]]) = ???
-
-    def getResultSet(index: Long, count: Int) = ???
-
-    def getResultSet(index: Long, count: Int, map: JMap[String, Class[_]]) = ???
-
-    def free() = { /* nothing to do */ }
-
-    override def toString = mkString(vList)
+    private def mkArray(v: List[T]): java.sql.Array = utils.SimpleArrayUtils.mkArray(mkString)(sqlBaseType, v)
   }
 }

--- a/core/src/main/scala/com/github/tminglei/slickpg/utils/PgCommonJdbcTypes.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/utils/PgCommonJdbcTypes.scala
@@ -1,7 +1,6 @@
 package com.github.tminglei.slickpg
 package utils
 
-import org.postgresql.util.PGobject
 import scala.slick.driver.{PostgresDriver, JdbcTypesComponent}
 import scala.reflect.ClassTag
 import java.sql.{PreparedStatement, ResultSet}
@@ -28,11 +27,6 @@ trait PgCommonJdbcTypes extends JdbcTypesComponent { driver: PostgresDriver =>
     override def valueToSQLLiteral(v: T) = if(v == null) "NULL" else s"'${fnToString(v)}'"
 
     ///
-    private def mkPgObject(v: T) = {
-      val obj = new PGobject
-      obj.setType(sqlTypeName)
-      obj.setValue(if(v == null) null else fnToString(v))
-      obj
-    }
+    private def mkPgObject(v: T) = mkPGobject(sqlTypeName, if(v == null) null else fnToString(v))
   }
 }

--- a/core/src/main/scala/com/github/tminglei/slickpg/utils/SimpleArrayUtils.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/utils/SimpleArrayUtils.scala
@@ -1,4 +1,8 @@
-package com.github.tminglei.slickpg.utils
+package com.github.tminglei.slickpg
+package utils
+
+import java.util.{Map => JMap}
+import scala.reflect.ClassTag
 
 object SimpleArrayUtils {
   import PgTokenHelper._
@@ -22,4 +26,37 @@ object SimpleArrayUtils {
         GroupToken(members)
       }
     })
+
+  def mkArray[T : ClassTag](mkString: (List[T] => String))(sqlBaseType: String, vList: List[T]): java.sql.Array =
+    new SimpleArray(sqlBaseType, vList, mkString)
+
+  ////////////////////////////////////////////////////////////////////////////////////
+
+  /** !!! NOTE: only used to transfer array data into driver/preparedStatement. !!! */
+  private class SimpleArray[T : ClassTag](sqlBaseTypeName: String, vList: List[T], mkString: (List[T] => String)) extends java.sql.Array {
+
+    def getBaseTypeName = sqlBaseTypeName.replaceFirst("^\"", "").replaceFirst("\"$", "")
+
+    def getBaseType = ???
+
+    def getArray = vList.toArray
+
+    def getArray(map: JMap[String, Class[_]]) = ???
+
+    def getArray(index: Long, count: Int) = ???
+
+    def getArray(index: Long, count: Int, map: JMap[String, Class[_]]) = ???
+
+    def getResultSet = ???
+
+    def getResultSet(map: JMap[String, Class[_]]) = ???
+
+    def getResultSet(index: Long, count: Int) = ???
+
+    def getResultSet(index: Long, count: Int, map: JMap[String, Class[_]]) = ???
+
+    def free() = { /* nothing to do */ }
+
+    override def toString = mkString(vList)
+  }
 }

--- a/core/src/main/scala/com/github/tminglei/slickpg/utils/package.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/utils/package.scala
@@ -1,0 +1,12 @@
+package com.github.tminglei.slickpg
+
+import org.postgresql.util.PGobject
+
+package object utils {
+  def mkPGobject(typeName: String, value: String) = {
+    val obj = new PGobject
+    obj.setType(typeName)
+    obj.setValue(value)
+    obj
+  }
+}

--- a/src/main/scala/com/github/tminglei/slickpg/PgArraySupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgArraySupport.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 import scala.slick.lifted.Column
 import scala.slick.driver.PostgresDriver
 import java.sql.{Timestamp, Time, Date}
-import scala.slick.jdbc.JdbcType
+import scala.slick.jdbc.{PositionedResult, JdbcType}
 
 trait PgArraySupport extends array.PgArrayExtensions with array.PgArrayJdbcTypes { driver: PostgresDriver =>
 
@@ -34,5 +34,14 @@ trait PgArraySupport extends array.PgArrayExtensions with array.PgArrayJdbcTypes
       implicit tm: JdbcType[B1], tm1: JdbcType[List[B1]]) = {
         new ArrayColumnExtensionMethods[B1, Option[List[B1]]](c)
       }
+
+    /// for static sql usage
+    implicit class PgArrayPositionedResult(val r: PositionedResult) {
+      // uuid array
+      def nextUUIDArray() = ???
+      def nextUUIDArrayOption() = ???
+      def updateUUIDArray(v: List[UUID]) = ???
+      def updateUUIDArrayOption(v: Option[List[UUID]]) = ???
+    }
   }
 }

--- a/src/main/scala/com/github/tminglei/slickpg/PgArraySupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgArraySupport.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 import scala.slick.lifted.Column
 import scala.slick.driver.PostgresDriver
 import java.sql.{Timestamp, Time, Date}
-import scala.slick.jdbc.{PositionedResult, JdbcType}
+import scala.slick.jdbc.{PositionedParameters, PositionedResult, JdbcType}
 
 trait PgArraySupport extends array.PgArrayExtensions with array.PgArrayJdbcTypes { driver: PostgresDriver =>
 
@@ -34,14 +34,97 @@ trait PgArraySupport extends array.PgArrayExtensions with array.PgArrayJdbcTypes
       implicit tm: JdbcType[B1], tm1: JdbcType[List[B1]]) = {
         new ArrayColumnExtensionMethods[B1, Option[List[B1]]](c)
       }
+  }
 
-    /// for static sql usage
+  /// static sql support, NOTE: no extension methods available for static sql usage
+  trait SimpleArrayPlainImplicits {
     implicit class PgArrayPositionedResult(val r: PositionedResult) {
       // uuid array
-      def nextUUIDArray() = ???
-      def nextUUIDArrayOption() = ???
-      def updateUUIDArray(v: List[UUID]) = ???
-      def updateUUIDArrayOption(v: Option[List[UUID]]) = ???
+      def nextUUIDArray() = nextArray[UUID].getOrElse(Nil)
+      def nextUUIDArrayOption() = nextArray[UUID]
+      // string array
+      def nextStringArray() = nextArray[String].getOrElse(Nil)
+      def nextStringArrayOption() = nextArray[String]
+      // long array
+      def nextLongArray() = nextArray[Long].getOrElse(Nil)
+      def nextLongArrayOption() = nextArray[Long]
+      // int array
+      def nextIntArray() = nextArray[Int].getOrElse(Nil)
+      def nextIntArrayOption() = nextArray[Int]
+      // short array
+      def nextShortArray() = nextArray[Short].getOrElse(Nil)
+      def nextShortArrayOption() = nextArray[Short]
+      // float array
+      def nextFloatArray() = nextArray[Float].getOrElse(Nil)
+      def nextFloatArrayOption() = nextArray[Float]
+      // double array
+      def nextDoubleArray() = nextArray[Double].getOrElse(Nil)
+      def nextDoubleArrayOption() = nextArray[Double]
+      // boolean array
+      def nextBooleanArray() = nextArray[Boolean].getOrElse(Nil)
+      def nextBooleanArrayOption() = nextArray[Boolean]
+      // date array
+      def nextDateArray() = nextArray[Date].getOrElse(Nil)
+      def nextDateArrayOption() = nextArray[Date]
+      // time array
+      def nextTimeArray() = nextArray[Time].getOrElse(Nil)
+      def nextTimeArrayOption() = nextArray[Time]
+      // timestamp array
+      def nextTimestampArray() = nextArray[Timestamp].getOrElse(Nil)
+      def nextTimestampArrayOption() = nextArray[Timestamp]
+
+      ///
+      private def nextArray[T](): Option[List[T]] = {
+        val value = r.rs.getArray(r.skip.currentPos)
+        if (r.rs.wasNull) None else Some(
+          value.getArray.asInstanceOf[Array[Any]].map(_.asInstanceOf[T]).toList)
+      }
+    }
+
+    implicit class PgArrayPositionedParameters(p: PositionedParameters) {
+      import utils.SimpleArrayUtils._
+      // uuid array
+      def setUUIDArray(v: List[UUID]) = setArray("uuid", Option(v))
+      def setUUIDArrayOption(v: Option[List[UUID]]) = setArray("uuid", v)
+      // string array
+      def setStringArray(v: List[String]) = setArray("text", Option(v))
+      def setStringArrayOption(v: Option[List[String]]) = setArray("text", v)
+      // long array
+      def setLongArray(v: List[String]) = setArray("int8", Option(v))
+      def setLongArrayOption(v: Option[List[String]]) = setArray("int8", v)
+      // int array
+      def setIntArray(v: List[Int]) = setArray("int4", Option(v))
+      def setIntArrayOption(v: Option[List[Int]]) = setArray("int4", v)
+      // short array
+      def setShortArray(v: List[Short]) = setArray("int2", Option(v))
+      def setShortArrayOption(v: Option[List[Short]]) = setArray("int2", v)
+      // float array
+      def setFloatArray(v: List[Float]) = setArray("float4", Option(v))
+      def setFloatArrayOption(v: Option[List[Float]]) = setArray("float8", v)
+      // double array
+      def setDoubleArray(v: List[Double]) = setArray("float8", Option(v))
+      def setDoubleArrayOption(v: Option[List[Double]]) = setArray("float8", v)
+      // boolean array
+      def setBooleanArray(v: List[Boolean]) = setArray("bool", Option(v))
+      def setBooleanArrayOption(v: Option[List[Boolean]]) = setArray("bool", v)
+      // date array
+      def setDateArray(v: List[Date]) = setArray("date", Option(v))
+      def setDateArrayOption(v: Option[List[Date]]) = setArray("date", v)
+      // time array
+      def setTimeArray(v: List[Time]) = setArray("time", Option(v))
+      def setTimeArrayOption(v: Option[List[Time]]) = setArray("time", v)
+      // timestamp array
+      def setTimestampArray(v: List[Timestamp]) = setArray("timestamp", Option(v))
+      def setTimestampArrayOption(v: Option[List[Timestamp]]) = setArray("timestamp", v)
+
+      ///
+      private def setArray[T](baseType: String, v: Option[List[T]]) = {
+        p.pos += 1
+        v match {
+          case Some(vList) => p.ps.setArray(p.pos, mkArray(mkString[T](_.toString))(baseType, vList))
+          case None        => p.ps.setNull(p.pos, java.sql.Types.ARRAY)
+        }
+      }
     }
   }
 }

--- a/src/main/scala/com/github/tminglei/slickpg/PgArraySupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgArraySupport.scala
@@ -1,6 +1,7 @@
 package com.github.tminglei.slickpg
 
 import java.util.UUID
+import scala.reflect.ClassTag
 import scala.slick.lifted.Column
 import scala.slick.driver.PostgresDriver
 import java.sql.{Timestamp, Time, Date}
@@ -118,7 +119,7 @@ trait PgArraySupport extends array.PgArrayExtensions with array.PgArrayJdbcTypes
       def setTimestampArrayOption(v: Option[List[Timestamp]]) = setArray("timestamp", v)
 
       ///
-      private def setArray[T](baseType: String, v: Option[List[T]]) = {
+      private def setArray[T: ClassTag](baseType: String, v: Option[List[T]]) = {
         p.pos += 1
         v match {
           case Some(vList) => p.ps.setArray(p.pos, mkArray(mkString[T](_.toString))(baseType, vList))

--- a/src/main/scala/com/github/tminglei/slickpg/PgArraySupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgArraySupport.scala
@@ -38,7 +38,7 @@ trait PgArraySupport extends array.PgArrayExtensions with array.PgArrayJdbcTypes
 
   /// static sql support, NOTE: no extension methods available for static sql usage
   trait SimpleArrayPlainImplicits {
-    implicit class PgArrayPositionedResult(val r: PositionedResult) {
+    implicit class PgArrayPositionedResult(r: PositionedResult) {
       // uuid array
       def nextUUIDArray() = nextArray[UUID].getOrElse(Nil)
       def nextUUIDArrayOption() = nextArray[UUID]

--- a/src/main/scala/com/github/tminglei/slickpg/PgEnumSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgEnumSupport.scala
@@ -1,6 +1,5 @@
 package com.github.tminglei.slickpg
 
-import org.postgresql.util.PGobject
 import scala.slick.jdbc.JdbcType
 import scala.slick.driver.PostgresDriver
 import scala.slick.lifted.Column
@@ -55,12 +54,8 @@ trait PgEnumSupport extends enums.PgEnumExtensions with array.PgArrayJdbcTypes {
       override def valueToSQLLiteral(v: enumObject.Value) = if (v eq null) "NULL" else s"'$v'"
 
       ///
-      private def mkPgObject(v: enumObject.Value) = {
-        val obj = new PGobject
-        obj.setType(if (quoteName) sqlEnumTypeName else sqlEnumTypeName.toLowerCase)
-        obj.setValue(if (v eq null) null else v.toString)
-        obj
-      }
+      private def mkPgObject(v: enumObject.Value) =
+        utils.mkPGobject( (if (quoteName) sqlEnumTypeName else sqlEnumTypeName.toLowerCase), (if (v eq null) null else v.toString) )
     }
   }
 }

--- a/src/main/scala/com/github/tminglei/slickpg/PgHStoreSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgHStoreSupport.scala
@@ -32,7 +32,7 @@ trait PgHStoreSupport extends hstore.PgHStoreExtensions with utils.PgCommonJdbcT
 
   /// static sql support, NOTE: no extension methods available for static sql usage
   trait SimpleHStorePlainImplicits {
-    implicit class PgHStorePositionedResult(val r: PositionedResult) {
+    implicit class PgHStorePositionedResult(r: PositionedResult) {
       def nextHStore() = nextHStoreOption().getOrElse(Map.empty)
       def nextHStoreOption() = r.nextStringOption().map { v =>
         WrapAsScala.mapAsScalaMap(HStoreConverter.fromString(v).asInstanceOf[java.util.Map[String, String]]).toMap

--- a/src/main/scala/com/github/tminglei/slickpg/PgHStoreSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgHStoreSupport.scala
@@ -4,7 +4,7 @@ import scala.collection.convert.{WrapAsJava, WrapAsScala}
 import scala.slick.driver.PostgresDriver
 import scala.slick.lifted.Column
 import org.postgresql.util.HStoreConverter
-import scala.slick.jdbc.JdbcType
+import scala.slick.jdbc.{PositionedParameters, PositionedResult, JdbcType}
 
 trait PgHStoreSupport extends hstore.PgHStoreExtensions with utils.PgCommonJdbcTypes { driver: PostgresDriver =>
 
@@ -28,5 +28,25 @@ trait PgHStoreSupport extends hstore.PgHStoreExtensions with utils.PgCommonJdbcT
       implicit tm: JdbcType[Map[String, String]], tm1: JdbcType[List[String]]) = {
         new HStoreColumnExtensionMethods[Option[Map[String, String]]](c)
       }
+  }
+
+  /// static sql support, NOTE: no extension methods available for static sql usage
+  trait SimpleHStorePlainImplicits {
+    implicit class PgHStorePositionedResult(val r: PositionedResult) {
+      def nextHStore() = nextHStoreOption().getOrElse(Map.empty)
+      def nextHStoreOption() = r.nextStringOption().map { v =>
+        WrapAsScala.mapAsScalaMap(HStoreConverter.fromString(v).asInstanceOf[java.util.Map[String, String]]).toMap
+      }
+    }
+    implicit class PgHStorePositionedParameters(p: PositionedParameters) {
+      def setHStore(v: Map[String,String]) = setHStoreOption(Option(v))
+      def setHStoreOption(v: Option[Map[String,String]]) = {
+        p.pos += 1
+        v match {
+          case Some(v) => p.ps.setObject(p.pos, utils.mkPGobject("hstore", HStoreConverter.toString(WrapAsJava.mapAsJavaMap(v))))
+          case None    => p.ps.setNull(p.pos, java.sql.Types.OTHER)
+        }
+      }
+    }
   }
 }

--- a/src/main/scala/com/github/tminglei/slickpg/PgJsonSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgJsonSupport.scala
@@ -1,7 +1,7 @@
 package com.github.tminglei.slickpg
 
 import scala.slick.driver.PostgresDriver
-import scala.slick.jdbc.JdbcType
+import scala.slick.jdbc.{PositionedParameters, PositionedResult, JdbcType}
 import scala.slick.lifted.Column
 
 /** simple json string wrapper */
@@ -31,5 +31,22 @@ trait PgJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes {
       implicit tm: JdbcType[JsonString], tm1: JdbcType[List[String]]) = {
         new JsonColumnExtensionMethods[JsonString, Option[JsonString]](c)
       }
+  }
+
+  trait SimpleJsonPlainImplicits {
+    implicit class PgJsonPositionedResult(r: PositionedResult) {
+      def nextJson() = nextJsonOption().orNull
+      def nextJsonOption() = r.nextStringOption().map(JsonString)
+    }
+    implicit class PgJsonPositionedParameters(p: PositionedParameters) {
+      def setJson(v: JsonString) = setJsonOption(Option(v))
+      def setJsonOption(v: Option[JsonString]) = {
+        p.pos += 1
+        v match {
+          case Some(v) => p.ps.setObject(p.pos, utils.mkPGobject("json", v.value))
+          case None    => p.ps.setNull(p.pos, java.sql.Types.OTHER)
+        }
+      }
+    }
   }
 }

--- a/src/main/scala/com/github/tminglei/slickpg/PgLTreeSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgLTreeSupport.scala
@@ -60,10 +60,7 @@ trait PgLTreeSupport extends ltree.PgLTreeExtensions with utils.PgCommonJdbcType
       def nextLTree() = nextLTreeOption().orNull
       def nextLTreeOption() = r.nextStringOption().map(LTree.apply)
       def nextLTreeArray() = nextLTreeArrayOption().getOrElse(Nil)
-      def nextLTreeArrayOption() = {
-        val value = r.rs.getString(r.skip.currentPos)
-        if (r.wasNull) None else Some(fromString(LTree.apply)(value))
-      }
+      def nextLTreeArrayOption() = r.nextStringOption().map(fromString(LTree.apply))
     }
     implicit class PgLTreePositionedParameters(p: PositionedParameters) {
       def setLTree(v: LTree) = setLTreeOption(Option(v))

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgArgonautSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgArgonautSupport.scala
@@ -2,7 +2,7 @@ package com.github.tminglei.slickpg
 
 import scala.slick.driver.PostgresDriver
 import scala.slick.lifted.Column
-import scala.slick.jdbc.JdbcType
+import scala.slick.jdbc.{PositionedParameters, PositionedResult, JdbcType}
 
 trait PgArgonautSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes { driver: PostgresDriver =>
   import argonaut._, Argonaut._
@@ -27,5 +27,22 @@ trait PgArgonautSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTyp
       implicit tm: JdbcType[Json], tm1: JdbcType[List[String]]) = {
         new JsonColumnExtensionMethods[Json, Option[Json]](c)
       }
+  }
+
+  trait SimpleJsonPlainImplicits {
+    implicit class PgJsonPositionedResult(r: PositionedResult) {
+      def nextJson() = nextJsonOption().getOrElse(jNull)
+      def nextJsonOption() = r.nextStringOption().map(_.parse)
+    }
+    implicit class PgJsonPositionedParameters(p: PositionedParameters) {
+      def setJson(v: Json) = setJsonOption(Option(v))
+      def setJsonOption(v: Option[Json]) = {
+        p.pos += 1
+        v match {
+          case Some(v) => p.ps.setObject(p.pos, utils.mkPGobject("json", v.nospaces))
+          case None    => p.ps.setNull(p.pos, java.sql.Types.OTHER)
+        }
+      }
+    }
   }
 }

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgArgonautSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgArgonautSupport.scala
@@ -29,7 +29,7 @@ trait PgArgonautSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTyp
       }
   }
 
-  trait SimpleJsonPlainImplicits {
+  trait ArgonautJsonPlainImplicits {
     implicit class PgJsonPositionedResult(r: PositionedResult) {
       def nextJson() = nextJsonOption().getOrElse(jNull)
       def nextJsonOption() = r.nextStringOption().map(_.parse)

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgDate2Support.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgDate2Support.scala
@@ -16,10 +16,10 @@ trait PgDate2Support extends date.PgDateExtensions with utils.PgCommonJdbcTypes 
   trait DateTimeImplicits extends Date2DateTimeImplicitsDuration
   trait DateTimeImplicitsPeriod extends Date2DateTimeImplicitsPeriod
 
-  trait Date2DateTimeImplicitsDuration extends BaseDateTimeImplicits[Duration]
-  trait Date2DateTimeImplicitsPeriod extends BaseDateTimeImplicits[Period]
+  trait Date2DateTimeImplicitsDuration extends Date2DateTimeImplicits[Duration]
+  trait Date2DateTimeImplicitsPeriod extends Date2DateTimeImplicits[Period]
 
-  trait BaseDateTimeFormatters {
+  trait Date2DateTimeFormatters {
     val date2DateFormatter = DateTimeFormatter.ISO_LOCAL_DATE
     val date2TimeFormatter = DateTimeFormatter.ISO_LOCAL_TIME
     val date2DateTimeFormatter =
@@ -47,7 +47,7 @@ trait PgDate2Support extends date.PgDateExtensions with utils.PgCommonJdbcTypes 
         .toFormatter()
   }
 
-  trait BaseDateTimeImplicits[INTERVAL] extends BaseDateTimeFormatters {
+  trait Date2DateTimeImplicits[INTERVAL] extends Date2DateTimeFormatters {
     implicit val date2DateTypeMapper = new GenericJdbcType[LocalDate]("date",
       LocalDate.parse(_, date2DateFormatter), _.format(date2DateFormatter), hasLiteralForm=false)
     implicit val date2TimeTypeMapper = new GenericJdbcType[LocalTime]("time",
@@ -119,7 +119,7 @@ trait PgDate2Support extends date.PgDateExtensions with utils.PgCommonJdbcTypes 
     }
   }
 
-  trait Date2DateTimeImplicits extends BaseDateTimeFormatters {
+  trait Date2DateTimePlainImplicits extends Date2DateTimeFormatters {
     import java.sql.Types
 
     implicit class PgDate2TimePositionedResult(r: PositionedResult) {

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgDateSupport2bp.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgDateSupport2bp.scala
@@ -16,10 +16,10 @@ trait PgDateSupport2bp extends date.PgDateExtensions with utils.PgCommonJdbcType
   trait DateTimeImplicits extends BpDateTimeImplicitsDuration
   trait DateTimeImplicitsPeriod extends BpDateTimeImplicitsPeriod
 
-  trait BpDateTimeImplicitsDuration extends BaseDateTimeImplicits[Duration]
-  trait BpDateTimeImplicitsPeriod extends BaseDateTimeImplicits[Period]
+  trait BpDateTimeImplicitsDuration extends BpDateTimeImplicits[Duration]
+  trait BpDateTimeImplicitsPeriod extends BpDateTimeImplicits[Period]
 
-  trait BaseDateTimeFormatters {
+  trait BpDateTimeFormatters {
     val bpDateFormatter = DateTimeFormatter.ISO_LOCAL_DATE
     val bpTimeFormatter = DateTimeFormatter.ISO_LOCAL_TIME
     val bpDateTimeFormatter =
@@ -47,7 +47,7 @@ trait PgDateSupport2bp extends date.PgDateExtensions with utils.PgCommonJdbcType
         .toFormatter()
   }
 
-  trait BaseDateTimeImplicits[INTERVAL] extends BaseDateTimeFormatters {
+  trait BpDateTimeImplicits[INTERVAL] extends BpDateTimeFormatters {
     implicit val bpDateTypeMapper = new GenericJdbcType[LocalDate]("date",
       LocalDate.parse(_, bpDateFormatter), _.format(bpDateFormatter), hasLiteralForm=false)
     implicit val bpTimeTypeMapper = new GenericJdbcType[LocalTime]("time",
@@ -119,7 +119,7 @@ trait PgDateSupport2bp extends date.PgDateExtensions with utils.PgCommonJdbcType
     }
   }
 
-  trait BaseDateTimePlainImplicits extends BaseDateTimeFormatters {
+  trait BpDateTimePlainImplicits extends BpDateTimeFormatters {
     import java.sql.Types
 
     implicit class PgDate2TimePositionedResult(r: PositionedResult) {

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgDateSupportJoda.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgDateSupportJoda.scala
@@ -3,6 +3,7 @@ package com.github.tminglei.slickpg
 import scala.slick.driver.PostgresDriver
 import org.joda.time._
 import org.joda.time.format.{ISODateTimeFormat, DateTimeFormat}
+import scala.slick.jdbc.{PositionedParameters, PositionedResult}
 import scala.slick.lifted.Column
 import org.postgresql.util.PGInterval
 
@@ -12,7 +13,7 @@ trait PgDateSupportJoda extends date.PgDateExtensions with utils.PgCommonJdbcTyp
   /// alias
   trait DateTimeImplicits extends JodaDateTimeImplicits
 
-  trait JodaDateTimeImplicits {
+  trait JodaDateTimeFormatters {
     val jodaDateFormatter = ISODateTimeFormat.date()
     val jodaTimeFormatter = DateTimeFormat.forPattern("HH:mm:ss.SSSSSS")
     val jodaTimeFormatter_NoFraction = DateTimeFormat.forPattern("HH:mm:ss")
@@ -20,7 +21,9 @@ trait PgDateSupportJoda extends date.PgDateExtensions with utils.PgCommonJdbcTyp
     val jodaDateTimeFormatter_NoFraction = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss")
     val jodaTzDateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSSZ")
     val jodaTzDateTimeFormatter_NoFraction = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ssZ")
+  }
 
+  trait JodaDateTimeImplicits extends JodaDateTimeFormatters {
     implicit val jodaDateTypeMapper = new GenericJdbcType[LocalDate]("date",
       LocalDate.parse(_, jodaDateFormatter), _.toString(jodaDateFormatter), hasLiteralForm=false)
     implicit val jodaTimeTypeMapper = new GenericJdbcType[LocalTime]("time",
@@ -63,6 +66,44 @@ trait PgDateSupportJoda extends date.PgDateExtensions with utils.PgCommonJdbcTyp
       new TimestampColumnExtensionMethods[LocalDate, LocalTime, DateTime, Period, DateTime](c)
     implicit def jodaTzTimestampOptColumnExtensionMethods(c: Column[Option[DateTime]]) =
       new TimestampColumnExtensionMethods[LocalDate, LocalTime, DateTime, Period, Option[DateTime]](c)
+  }
+
+  trait JodaDateTimePlainImplicits extends JodaDateTimeFormatters {
+    import java.sql.Types
+
+    implicit class PgDate2TimePositionedResult(r: PositionedResult) {
+      def nextLocalDate() = nextLocalDateOption().orNull
+      def nextLocalDateOption() = r.nextStringOption().map(LocalDate.parse(_, jodaDateFormatter))
+      def nextLocalTime() = nextLocalTimeOption().orNull
+      def nextLocalTimeOption() = r.nextStringOption().map(LocalTime.parse(_, jodaTimeFormatter))
+      def nextLocalDateTime() = nextLocalDateTimeOption().orNull
+      def nextLocalDateTimeOption() = r.nextStringOption().map(LocalDateTime.parse(_, jodaDateTimeFormatter))
+      def nextZonedDateTime() = nextZonedDateTimeOption().orNull
+      def nextZonedDateTimeOption() = r.nextStringOption().map(DateTime.parse(_, jodaTzDateTimeFormatter))
+      def nextPeriod() = nextPeriodOption().orNull
+      def nextPeriodOption() = r.nextStringOption().map(pgIntervalStr2jodaPeriod)
+    }
+
+    implicit class PgDate2PositionedParameters(p: PositionedParameters) {
+      def setLocalDate(v: LocalDate) = setLocalDateOption(Option(v))
+      def setLocalDateOption(v: Option[LocalDate]) = setDateTimeInternal(Types.OTHER, "date", v.map(_.toString(jodaDateFormatter)))
+      def setLocalTime(v: LocalTime) = setLocalTimeOption(Option(v))
+      def setLocalTimeOption(v: Option[LocalTime]) = setDateTimeInternal(Types.OTHER, "time", v.map(_.toString(jodaTimeFormatter)))
+      def setLocalDateTime(v: LocalDateTime) = setLocalDateTimeOption(Option(v))
+      def setLocalDateTimeOption(v: Option[LocalDateTime]) = setDateTimeInternal(Types.OTHER, "timestamp", v.map(_.toString(jodaDateTimeFormatter)))
+      def setZonedDateTime(v: DateTime) = setZonedDateTimeOption(Option(v))
+      def setZonedDateTimeOption(v: Option[DateTime]) = setDateTimeInternal(Types.OTHER, "timestamptz", v.map(_.toString(jodaTzDateTimeFormatter)))
+      def setPeriod(v: Period) = setPeriodOption(Option(v))
+      def setPeriodOption(v: Option[Period]) = setDateTimeInternal(Types.OTHER, "interval", v.map(_.toString))
+      ///
+      private def setDateTimeInternal(sqlType: Int, typeName: String, v: => Option[String]) = {
+        p.pos += 1
+        v match {
+          case Some(v) => p.ps.setObject(p.pos, utils.mkPGobject(typeName, v))
+          case None    => p.ps.setNull(p.pos, sqlType)
+        }
+      }
+    }
   }
 }
 

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgJson4sSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgJson4sSupport.scala
@@ -2,7 +2,7 @@ package com.github.tminglei.slickpg
 
 import scala.slick.driver.PostgresDriver
 import scala.slick.lifted.Column
-import scala.slick.jdbc.JdbcType
+import scala.slick.jdbc.{PositionedParameters, PositionedResult, JdbcType}
 
 trait PgJson4sSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes { driver: PostgresDriver =>
   import org.json4s._
@@ -31,5 +31,22 @@ trait PgJson4sSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes
       implicit tm: JdbcType[JValue], tm1: JdbcType[List[String]]) = {
         new JsonColumnExtensionMethods[JValue, Option[JValue]](c)
       }
+  }
+
+  trait SimpleJsonPlainImplicits {
+    implicit class PgJsonPositionedResult(r: PositionedResult) {
+      def nextJson() = nextJsonOption().getOrElse(JNull)
+      def nextJsonOption() = r.nextStringOption().map(jsonMethods.parse(_))
+    }
+    implicit class PgJsonPositionedParameters(p: PositionedParameters) {
+      def setJson(v: JValue) = setJsonOption(Option(v))
+      def setJsonOption(v: Option[JValue]) = {
+        p.pos += 1
+        v match {
+          case Some(v) => p.ps.setObject(p.pos, utils.mkPGobject("json", jsonMethods.compact(jsonMethods.render(v))))
+          case None    => p.ps.setNull(p.pos, java.sql.Types.OTHER)
+        }
+      }
+    }
   }
 }

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgJson4sSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgJson4sSupport.scala
@@ -33,7 +33,7 @@ trait PgJson4sSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes
       }
   }
 
-  trait SimpleJsonPlainImplicits {
+  trait Json4sJsonPlainImplicits {
     implicit class PgJsonPositionedResult(r: PositionedResult) {
       def nextJson() = nextJsonOption().getOrElse(JNull)
       def nextJsonOption() = r.nextStringOption().map(jsonMethods.parse(_))

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgPlayJsonSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgPlayJsonSupport.scala
@@ -28,7 +28,7 @@ trait PgPlayJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTyp
       }
   }
 
-  trait SimpleJsonPlainImplicits {
+  trait PlayJsonPlainImplicits {
     implicit class PgJsonPositionedResult(r: PositionedResult) {
       def nextJson() = nextJsonOption().getOrElse(JsNull)
       def nextJsonOption() = r.nextStringOption().map(Json.parse)

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgPlayJsonSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgPlayJsonSupport.scala
@@ -2,7 +2,7 @@ package com.github.tminglei.slickpg
 
 import scala.slick.driver.PostgresDriver
 import scala.slick.lifted.Column
-import scala.slick.jdbc.JdbcType
+import scala.slick.jdbc.{PositionedParameters, PositionedResult, JdbcType}
 
 trait PgPlayJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes { driver: PostgresDriver =>
   import play.api.libs.json._
@@ -26,5 +26,22 @@ trait PgPlayJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTyp
       implicit tm: JdbcType[JsValue], tm1: JdbcType[List[String]]) = {
         new JsonColumnExtensionMethods[JsValue, Option[JsValue]](c)
       }
+  }
+
+  trait SimpleJsonPlainImplicits {
+    implicit class PgJsonPositionedResult(r: PositionedResult) {
+      def nextJson() = nextJsonOption().getOrElse(JsNull)
+      def nextJsonOption() = r.nextStringOption().map(Json.parse)
+    }
+    implicit class PgJsonPositionedParameters(p: PositionedParameters) {
+      def setJson(v: JsValue) = setJsonOption(Option(v))
+      def setJsonOption(v: Option[JsValue]) = {
+        p.pos += 1
+        v match {
+          case Some(v) => p.ps.setObject(p.pos, utils.mkPGobject("json", Json.stringify(v)))
+          case None    => p.ps.setNull(p.pos, java.sql.Types.OTHER)
+        }
+      }
+    }
   }
 }

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgSprayJsonSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgSprayJsonSupport.scala
@@ -2,7 +2,7 @@ package com.github.tminglei.slickpg
 
 import scala.slick.driver.PostgresDriver
 import scala.slick.lifted.Column
-import scala.slick.jdbc.JdbcType
+import scala.slick.jdbc.{PositionedParameters, PositionedResult, JdbcType}
 
 trait PgSprayJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes { driver: PostgresDriver =>
   import spray.json._
@@ -28,5 +28,22 @@ trait PgSprayJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTy
       implicit tm: JdbcType[JsValue], tm1: JdbcType[List[String]]) = {
         new JsonColumnExtensionMethods[JsValue, Option[JsValue]](c)
       }
+  }
+
+  trait SimpleJsonPlainImplicits {
+    implicit class PgJsonPositionedResult(r: PositionedResult) {
+      def nextJson() = nextJsonOption().getOrElse(JsNull)
+      def nextJsonOption() = r.nextStringOption().map(_.parseJson)
+    }
+    implicit class PgJsonPositionedParameters(p: PositionedParameters) {
+      def setJson(v: JsValue) = setJsonOption(Option(v))
+      def setJsonOption(v: Option[JsValue]) = {
+        p.pos += 1
+        v match {
+          case Some(v) => p.ps.setObject(p.pos, utils.mkPGobject("json", v.toJson.compactPrint))
+          case None    => p.ps.setNull(p.pos, java.sql.Types.OTHER)
+        }
+      }
+    }
   }
 }

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgSprayJsonSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgSprayJsonSupport.scala
@@ -30,7 +30,7 @@ trait PgSprayJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTy
       }
   }
 
-  trait SimpleJsonPlainImplicits {
+  trait SprayJsonPlainImplicits {
     implicit class PgJsonPositionedResult(r: PositionedResult) {
       def nextJson() = nextJsonOption().getOrElse(JsNull)
       def nextJsonOption() = r.nextStringOption().map(_.parseJson)


### PR DESCRIPTION
Add static sql type mapping support

How to use it?

Declare your custmization postgres driver as below:
```scala
import slick.driver.PostgresDriver
import com.github.tminglei.slickpg._

trait MyPostgresDriver extends PostgresDriver
                          with PgArraySupport
                          with PgDateSupportJoda
                          with PgRangeSupport
                          with PgHStoreSupport
                          with PgPlayJsonSupport
                          with PgPostGISSupport {

  override lazy val Implicit = new ImplicitsPlus {}
  override val simple = new SimpleQLPlus {}

  //////
  trait ImplicitsPlus extends Implicits
                        with SimpleArrayPlainImplicits
                        with JodaDateTimePlainImplicits
                        with SimpleRangePlainImplicits
                        with SimpleHStorePlainImplicits
                        with PlayJsonPlainImplicits
                        with PostGISPlainImplicits

  trait SimpleQLPlus extends SimpleQL with ImplicitsPlus
}

object MyPostgresDriver extends MyPostgresDriver
```

Then add `import MyPostgresDriver.simple._` to your classes and use it.