### PR TITLE
Enhance json support for postgres 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
 services:
   - postgresql
 addons:
-  postgresql: "9.3"
+  postgresql: "9.4"
 before_script:
   - psql -c 'create database test;' -U postgres
   - psql test -c 'CREATE EXTENSION IF NOT EXISTS hstore;' -U postgres

--- a/core/src/main/scala/com/github/tminglei/slickpg/json/PgJsonExtensions.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/json/PgJsonExtensions.scala
@@ -1,55 +1,117 @@
 package com.github.tminglei.slickpg
 package json
 
+import scala.slick.ast.{LiteralNode, Library}
 import scala.slick.ast.Library.{SqlFunction, SqlOperator}
-import scala.slick.lifted.{ExtensionMethods, Column}
+import scala.slick.lifted.{FunctionSymbolExtensionMethods, OptionMapperDSL, ExtensionMethods, Column}
 import scala.slick.driver.{JdbcTypesComponent, PostgresDriver}
 import scala.slick.jdbc.JdbcType
 
 trait PgJsonExtensions extends JdbcTypesComponent { driver: PostgresDriver =>
   import driver.Implicit._
+  import FunctionSymbolExtensionMethods._
 
-  object JsonLibrary {
+  trait BaseJsonAssistants[JSONType] {
+    def toJson[P, R](e: Column[P])(implicit tm: JdbcType[JSONType], tm1: JdbcType[P],
+          om: OptionMapperDSL.arg[Any, P]#to[JSONType, R]) =
+      tm.sqlTypeName.toLowerCase match {
+        case "json"  => om.column(JsonLibrary(tm.sqlTypeName).toJson, e.toNode)
+        case "jsonb" => om.column(Library.Cast, JsonLibrary(tm.sqlTypeName).toJson.column[JSONType](e.toNode).toNode, LiteralNode(tm.sqlTypeName))
+        case _  => new IllegalArgumentException("unsupported json type: " + tm.sqlTypeName)
+      }
+    def arrayToJson[P, R](e: Column[P], prettyBool: Option[Boolean] = None)(implicit tm: JdbcType[JSONType],
+          tm1: JdbcType[P], om: OptionMapperDSL.arg[List[Any], P]#to[JSONType, R]) =
+      tm.sqlTypeName.toLowerCase match {
+        case "json"  => prettyBool match {
+          case Some(bool) => om.column(JsonLibrary(tm.sqlTypeName).arrayToJson, e.toNode, LiteralNode(bool))
+          case None => om.column(JsonLibrary(tm.sqlTypeName).arrayToJson, e.toNode)
+        }
+        case "jsonb" => prettyBool match {
+          case Some(bool) => om.column(Library.Cast, JsonLibrary(tm.sqlTypeName).arrayToJson.column[JSONType](e.toNode, LiteralNode(bool)).toNode, LiteralNode(tm.sqlTypeName))
+          case None => om.column(Library.Cast, JsonLibrary(tm.sqlTypeName).arrayToJson.column[JSONType](e.toNode).toNode, LiteralNode(tm.sqlTypeName))
+        }
+        case _  => new IllegalArgumentException("unsupported json type: " + tm.sqlTypeName)
+      }
+    def jsonObject[P, R](pairs: Column[P])(implicit tm: JdbcType[JSONType], tm1: JdbcType[P],
+          om: OptionMapperDSL.arg[List[String], P]#to[JSONType, R]) =
+      tm.sqlTypeName.toLowerCase match {
+        case "json"  => om.column(JsonLibrary(tm.sqlTypeName).jsonObject, pairs.toNode)
+        case "jsonb" => om.column(Library.Cast, JsonLibrary(tm.sqlTypeName).jsonObject.column[JSONType](pairs.toNode).toNode, LiteralNode(tm.sqlTypeName))
+        case _  => new IllegalArgumentException("unsupported json type: " + tm.sqlTypeName)
+      }
+    def jsonObject[P1, P2, R](keys: Column[P1], vals: Column[P2])(implicit tm: JdbcType[JSONType], tm1: JdbcType[P1],
+          tm2: JdbcType[P2], om: OptionMapperDSL.arg[List[String], P1]#arg[List[String], P2]#to[JSONType, R]) =
+      tm.sqlTypeName.toLowerCase match {
+        case "json"  => om.column(JsonLibrary(tm.sqlTypeName).jsonObject, keys.toNode, vals.toNode)
+        case "jsonb" => om.column(Library.Cast, JsonLibrary(tm.sqlTypeName).jsonObject.column[JSONType](keys.toNode, vals.toNode).toNode, LiteralNode(tm.sqlTypeName))
+        case _  => new IllegalArgumentException("unsupported json type: " + tm.sqlTypeName)
+      }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  case class JsonLibrary(pgjson: String) {
     val Arrow  = new SqlOperator("->")
     val BiArrow = new SqlOperator("->>")
     val PoundArrow  = new SqlOperator("#>")
     val PoundBiArrow = new SqlOperator("#>>")
+    val Contains = new SqlOperator("@>")
+    val ContainsBy = new SqlOperator("<@")
+//    val Exists = new SqlOperator("?")
+//    val ExistsAny = new SqlOperator("?|")
+//    val ExistsAll = new SqlOperator("?&")
 
-    val arrayLength = new SqlFunction("json_array_length")
-    val arrayElements = new SqlFunction("json_array_elements")
-    val objectKeys = new SqlFunction("json_object_keys")
+    val toJson = new SqlFunction("to_json")
+    val arrayToJson = new SqlFunction("array_to_json")
 //    val rowToJson = new SqlFunction("row_to_json")  //not support, since "row" type not supported by slick/slick-pg yet
-//    val jsonEach = new SqlFunction("json_each")   //not support, since "row" type not supported by slick/slick-pg yet
-//    val jsonEachText = new SqlFunction("json_each_text")  //not support, since "row" type not supported by slick/slick-pg yet
-//    val jsonPopulateRecord = new SqlFunction("json_populate_record")  //not support, since "row" type not supported by slick/slick-pg yet
-//    val jsonPopulateRecordset = new SqlFunction("json_populate_recordset")  //not support, since "row" type not supported by slick/slick-pg yet
+    val jsonObject = new SqlFunction("json_object")
+
+    val typeof = new SqlFunction(pgjson + "_typeof")
+    val objectKeys = new SqlFunction(pgjson + "_object_keys")
+    val arrayLength = new SqlFunction(pgjson + "_array_length")
+    val arrayElements = new SqlFunction(pgjson + "_array_elements")
+    val arrayElementsText = new SqlFunction(pgjson + "_array_elements_text")
+//    val jsonEach = new SqlFunction(pgjson + "_each")   //not support, since "row" type not supported by slick/slick-pg yet
+//    val jsonEachText = new SqlFunction(pgjson + "_each_text")  //not support, since "row" type not supported by slick/slick-pg yet
+//    val jsonPopulateRecord = new SqlFunction(pgjson + "_populate_record")  //not support, since "row" type not supported by slick/slick-pg yet
+//    val jsonPopulateRecordset = new SqlFunction(pgjson + "_populate_recordset")  //not support, since "row" type not supported by slick/slick-pg yet
+//    val jsonToRecord = new SqlFunction(pgjson + "_to_record")  //not support, since "row" type not supported by slick/slick-pg yet
+//    val jsonToRecordSet = new SqlFunction(pgjson + "_to_recordset")  //not support, since "row" type not supported by slick/slick-pg yet
   }
 
   class JsonColumnExtensionMethods[JSONType, P1](val c: Column[P1])(
                 implicit tm: JdbcType[JSONType], tm1: JdbcType[List[String]]) extends ExtensionMethods[JSONType, P1] {
-
+    val jsonLib = JsonLibrary(tm.sqlTypeName)
     /** Note: json array's index starts with 0   */
     def ~> [P2, R](index: Column[P2])(implicit om: o#arg[Int, P2]#to[JSONType, R]) = {
-        om.column(JsonLibrary.Arrow, n, index.toNode)
+        om.column(jsonLib.Arrow, n, index.toNode)
       }
     def ~>>[P2, R](index: Column[P2])(implicit om: o#arg[Int, P2]#to[String, R]) = {
-        om.column(JsonLibrary.BiArrow, n, index.toNode)
+        om.column(jsonLib.BiArrow, n, index.toNode)
       }
     def +> [P2, R](key: Column[P2])(implicit om: o#arg[String, P2]#to[JSONType, R]) = {
-        om.column(JsonLibrary.Arrow, n, key.toNode)
+        om.column(jsonLib.Arrow, n, key.toNode)
       }
     def +>>[P2, R](key: Column[P2])(implicit om: o#arg[String, P2]#to[String, R]) = {
-        om.column(JsonLibrary.BiArrow, n, key.toNode)
+        om.column(jsonLib.BiArrow, n, key.toNode)
       }
     def #> [P2, R](keyPath: Column[P2])(implicit om: o#arg[List[String], P2]#to[JSONType, R]) = {
-        om.column(JsonLibrary.PoundArrow, n, keyPath.toNode)
+        om.column(jsonLib.PoundArrow, n, keyPath.toNode)
       }
     def #>>[P2, R](keyPath: Column[P2])(implicit om: o#arg[List[String], P2]#to[String, R]) = {
-        om.column(JsonLibrary.PoundBiArrow, n, keyPath.toNode)
+        om.column(jsonLib.PoundBiArrow, n, keyPath.toNode)
+      }
+    def @>[P2,R](c2: Column[P2])(implicit om: o#arg[JSONType, P2]#to[Boolean, R]) = {
+        om.column(jsonLib.Contains, n, c2.toNode)
+      }
+    def <@:[P2,R](c2: Column[P2])(implicit om: o#arg[JSONType, P2]#to[Boolean, R]) = {
+        om.column(jsonLib.ContainsBy, c2.toNode, n)
       }
 
-    def arrayLength[R](implicit om: o#to[Int, R]) = om.column(JsonLibrary.arrayLength, n)
-    def arrayElements[R](implicit om: o#to[JSONType, R]) = om.column(JsonLibrary.arrayElements, n)
-    def objectKeys[R](implicit om: o#to[String, R]) = om.column(JsonLibrary.objectKeys, n)
+    def tpe[R](implicit om: o#to[String, R]) = om.column(jsonLib.typeof, n)
+    def objectKeys[R](implicit om: o#to[String, R]) = om.column(jsonLib.objectKeys, n)
+    def arrayLength[R](implicit om: o#to[Int, R]) = om.column(jsonLib.arrayLength, n)
+    def arrayElements[R](implicit om: o#to[JSONType, R]) = om.column(jsonLib.arrayElements, n)
+    def arrayElementsText[R](implicit om: o#to[String, R]) = om.column(jsonLib.arrayElementsText, n)
   }
 }

--- a/src/main/scala/com/github/tminglei/slickpg/PgJsonSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgJsonSupport.scala
@@ -12,12 +12,15 @@ case class JsonString(value: String)
  */
 trait PgJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes { driver: PostgresDriver =>
 
+  val pgjson = "json"
+
   /// alias
   trait JsonImplicits extends SimpleJsonImplicits
 
   trait SimpleJsonImplicits {
     implicit val simpleJsonTypeMapper =
-      new GenericJdbcType[JsonString]("json",
+      new GenericJdbcType[JsonString](
+        pgjson,
         (v) => JsonString(v),
         (v) => v.value,
         hasLiteralForm = false

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgArgonautSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgArgonautSupport.scala
@@ -7,13 +7,15 @@ import scala.slick.jdbc.{SetParameter, PositionedParameters, PositionedResult, J
 trait PgArgonautSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes { driver: PostgresDriver =>
   import argonaut._, Argonaut._
 
+  val pgjson = "json"
+
   /// alias
   trait JsonImplicits extends ArgonautJsonImplicits
 
   trait ArgonautJsonImplicits {
     implicit val argonautJsonTypeMapper =
       new GenericJdbcType[Json](
-        "json",
+        pgjson,
         (s) => s.parse.toOption.getOrElse(jNull),
         (v) => v.nospaces,
         hasLiteralForm = false

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgJson4sSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgJson4sSupport.scala
@@ -8,6 +8,7 @@ trait PgJson4sSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes
   import org.json4s._
 
   type DOCType
+  val pgjson = "json"
 
   val jsonMethods: JsonMethods[DOCType]
 
@@ -17,7 +18,7 @@ trait PgJson4sSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes
   trait Json4sJsonImplicits {
     implicit val json4sJsonTypeMapper =
       new GenericJdbcType[JValue](
-        "json",
+        pgjson,
         (s) => jsonMethods.parse(s),
         (v) => jsonMethods.compact(jsonMethods.render(v)),
         hasLiteralForm = false

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgPlayJsonSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgPlayJsonSupport.scala
@@ -7,12 +7,15 @@ import scala.slick.jdbc.{SetParameter, PositionedParameters, PositionedResult, J
 trait PgPlayJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes { driver: PostgresDriver =>
   import play.api.libs.json._
 
+  val pgjson = "json"
+
   /// alias
   trait JsonImplicits extends PlayJsonImplicits
 
   trait PlayJsonImplicits {
     implicit val playJsonTypeMapper =
-      new GenericJdbcType[JsValue]("json",
+      new GenericJdbcType[JsValue](
+        pgjson,
         (v) => Json.parse(v),
         (v) => Json.stringify(v),
         hasLiteralForm = false

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgSprayJsonSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgSprayJsonSupport.scala
@@ -8,13 +8,15 @@ trait PgSprayJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTy
   import spray.json._
   import DefaultJsonProtocol._ // !!! IMPORTANT, otherwise `convertTo` and `toJson` won't work correctly.
 
+  val pgjson = "json"
+
   /// alias
   trait JsonImplicits extends SparyJsonImplicits
 
   trait SparyJsonImplicits {
     implicit val sparyJsonTypeMapper =
       new GenericJdbcType[JsValue](
-        "json",
+        pgjson,
         (s) => s.parseJson,
         (v) => v.toJson.compactPrint,
         hasLiteralForm = false

--- a/src/test/scala/com/github/tminglei/slickpg/MyPostgresDriver.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/MyPostgresDriver.scala
@@ -9,6 +9,7 @@ trait MyPostgresDriver extends ExPostgresDriver
                           with PgRangeSupport
                           with PgHStoreSupport
                           with PgSearchSupport {
+  override val pgjson = "jsonb"
   ///
   override lazy val Implicit = new ImplicitsPlus {}
   override val simple = new SimpleQLPlus {}

--- a/src/test/scala/com/github/tminglei/slickpg/PgJsonSupportTest.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgJsonSupportTest.scala
@@ -7,7 +7,7 @@ import scala.slick.jdbc.{StaticQuery => Q, GetResult}
 import scala.util.Try
 
 class PgJsonSupportTest {
-  import com.github.tminglei.slickpg.MyPostgresDriver.simple._
+  import MyPostgresDriver.simple._
 
   val db = Database.forURL(url = dbUrl, driver = "org.postgresql.Driver")
 
@@ -47,7 +47,7 @@ class PgJsonSupportTest {
 
       val q11 = JsonTests.filter(_.json.+>>("a") === "101".bind).map(_.json.+>>("c"))
       println(s"[json] '+>>' sql = ${q11.selectStatement}")
-      assertEquals("[3,4,5,9]", q11.first.value.replace(" ", ""))
+      assertEquals("[3,4,5,9]", q11.first.replace(" ", ""))
 
       val q12 = JsonTests.filter(_.json.+>>("a") === "101".bind).map(_.json.+>("c"))
       println(s"[json] '+>' sql = ${q12.selectStatement}")
@@ -74,6 +74,10 @@ class PgJsonSupportTest {
       println(s"[json] 'arrayElements' sql = ${q41.selectStatement}")
       assertEquals(json1, q41.first.value.replace(" ", ""))
 
+      val q42 = JsonTests.filter(_.id === testRec2.id).map(_.json.arrayElementsText)
+      println(s"[json] 'arrayElementsText' sql = ${q42.selectStatement}")
+      assertEquals(json1, q42.first.replace(" ", ""))
+
       val q5 = JsonTests.filter(_.id === testRec1.id).map(_.json.objectKeys)
       println(s"[json] 'objectKeys' sql = ${q5.selectStatement}")
       assertEquals(List("a","b","c"), q5.list)
@@ -81,6 +85,18 @@ class PgJsonSupportTest {
       val q51 = JsonTests.filter(_.id === testRec1.id).map(_.json.objectKeys)
       println(s"[json] 'objectKeys' sql = ${q51.selectStatement}")
       assertEquals("a", q51.first)
+
+      val q6 = JsonTests.filter(_.json @> JsonString(""" {"b":"aaa"} """).bind).map(_.id)
+      println(s"[json] '@>' sql = ${q6.selectStatement}")
+      assertEquals(33L, q6.first)
+
+      val q7 = JsonTests.filter(JsonString(""" {"b":"aaa"} """).bind <@: _.json).map(_.id)
+      println(s"[json] '<@' sql = ${q7.selectStatement}")
+      assertEquals(33L, q7.first)
+
+      val q8 = JsonTests.filter(_.id === testRec1.id).map(_.json.+>("a").jsonType)
+      println(s"[json] 'typeof' sql = ${q8.selectStatement}")
+      assertEquals("number", q8.first.toLowerCase)
     }
   }
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgJsonSupportTest.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgJsonSupportTest.scala
@@ -60,7 +60,7 @@ class PgJsonSupportTest {
 
       val q21 = JsonTests.filter(_.id === testRec2.id).map(_.json.~>>(1))
       println(s"[json] '~>>' sql = ${q21.selectStatement}")
-      assertEquals("""{"a":"v5","b":3}""", q21.first)
+      assertEquals("""{"a":"v5","b":3}""", q21.first.replace(" ", ""))
 
       val q3 = JsonTests.filter(_.id === testRec2.id).map(_.json.arrayLength)
       println(s"[json] 'arrayLength' sql = ${q3.selectStatement}")

--- a/src/test/scala/com/github/tminglei/slickpg/addon/PgArgonautSupportTest.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/addon/PgArgonautSupportTest.scala
@@ -12,6 +12,7 @@ class PgArgonautSupportTest {
   object MyPostgresDriver extends PostgresDriver
                             with PgArgonautSupport
                             with array.PgArrayJdbcTypes {
+    override val pgjson = "jsonb"
 
     override lazy val Implicit = new Implicits with JsonImplicits
     override val simple = new Implicits with SimpleQL with JsonImplicits {
@@ -62,7 +63,7 @@ class PgArgonautSupportTest {
 
       val q11 = JsonTests.filter(_.json.+>>("a") === "101".bind).map(_.json.+>>("c"))
       println(s"[argonaut] '+>>' sql = ${q11.selectStatement}")
-      assertEquals("[3,4,5,9]", q11.first)
+      assertEquals("[3,4,5,9]", q11.first.replace(" ", ""))
 
       val q12 = JsonTests.filter(_.json.+>>("a") === "101".bind).map(_.json.+>("c"))
       println(s"[argonaut] '+>' sql = ${q12.selectStatement}")
@@ -75,7 +76,7 @@ class PgArgonautSupportTest {
 
       val q21 = JsonTests.filter(_.id === testRec2.id).map(_.json.~>>(1))
       println(s"[argonaut] '~>>' sql = ${q21.selectStatement}")
-      assertEquals("""{"a":"v5","b":3}""", q21.first)
+      assertEquals("""{"a":"v5","b":3}""", q21.first.replace(" ", ""))
 
       val q3 = JsonTests.filter(_.id === testRec2.id).map(_.json.arrayLength)
       println(s"[argonaut] 'arrayLength' sql = ${q3.selectStatement}")

--- a/src/test/scala/com/github/tminglei/slickpg/addon/PgArgonautSupportTest.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/addon/PgArgonautSupportTest.scala
@@ -90,6 +90,10 @@ class PgArgonautSupportTest {
       println(s"[argonaut] 'arrayElements' sql = ${q41.selectStatement}")
       assertEquals(json1, q41.first)
 
+      val q42 = JsonTests.filter(_.id === testRec2.id).map(_.json.arrayElementsText)
+      println(s"[json] 'arrayElementsText' sql = ${q42.selectStatement}")
+      assertEquals(json1.toString.replace(" ", ""), q42.first.replace(" ", ""))
+
       val q5 = JsonTests.filter(_.id === testRec1.id).map(_.json.objectKeys)
       println(s"[argonaut] 'objectKeys' sql = ${q5.selectStatement}")
       assertEquals(List("a","b","c"), q5.list)
@@ -97,6 +101,18 @@ class PgArgonautSupportTest {
       val q51 = JsonTests.filter(_.id === testRec1.id).map(_.json.objectKeys)
       println(s"[argonaut] 'objectKeys' sql = ${q51.selectStatement}")
       assertEquals("a", q51.first)
+
+      val q6 = JsonTests.filter(_.json @> """ {"b":"aaa"} """.parse.toOption.getOrElse(jNull)).map(_.id)
+      println(s"[json] '@>' sql = ${q6.selectStatement}")
+      assertEquals(33L, q6.first)
+
+      val q7 = JsonTests.filter(""" {"b":"aaa"} """.parse.toOption.getOrElse(jNull) <@: _.json).map(_.id)
+      println(s"[json] '<@' sql = ${q7.selectStatement}")
+      assertEquals(33L, q7.first)
+
+      val q8 = JsonTests.filter(_.id === testRec1.id).map(_.json.+>("a").jsonType)
+      println(s"[json] 'typeof' sql = ${q8.selectStatement}")
+      assertEquals("number", q8.first.toLowerCase)
     }
   }
 

--- a/src/test/scala/com/github/tminglei/slickpg/addon/PgJson4sSupportTest.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/addon/PgJson4sSupportTest.scala
@@ -108,6 +108,10 @@ class PgJson4sSupportTest {
       println(s"[json4s] 'arrayElements' sql = ${q61.selectStatement}")
       assertEquals(json1, q61.first)
 
+      val q62 = JsonTests.filter(_.id === testRec2.id).map(_.json.arrayElementsText)
+      println(s"[json] 'arrayElementsText' sql = ${q62.selectStatement}")
+      assertEquals(compact(render(json1)), q62.first.replace(" ", ""))
+
       val q7 = JsonTests.filter(_.id === testRec1.id).map(_.json.objectKeys)
       println(s"[json4s] 'objectKeys' sql = ${q7.selectStatement}")
       assertEquals(List("a","b","c"), q7.list)
@@ -115,6 +119,18 @@ class PgJson4sSupportTest {
       val q71 = JsonTests.filter(_.id === testRec1.id).map(_.json.objectKeys)
       println(s"[json4s] 'objectKeys' sql = ${q71.selectStatement}")
       assertEquals("a", q71.first)
+
+      val q8 = JsonTests.filter(_.json @> parse(""" {"b":"aaa"} """)).map(_.id)
+      println(s"[json] '@>' sql = ${q8.selectStatement}")
+      assertEquals(33L, q8.first)
+
+      val q9 = JsonTests.filter(parse(""" {"b":"aaa"} """) <@: _.json).map(_.id)
+      println(s"[json] '<@' sql = ${q9.selectStatement}")
+      assertEquals(33L, q9.first)
+
+      val q10 = JsonTests.filter(_.id === testRec1.id).map(_.json.+>("a").jsonType)
+      println(s"[json] 'typeof' sql = ${q10.selectStatement}")
+      assertEquals("number", q10.first.toLowerCase)
     }
   }
 

--- a/src/test/scala/com/github/tminglei/slickpg/addon/PgJson4sSupportTest.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/addon/PgJson4sSupportTest.scala
@@ -13,6 +13,7 @@ class PgJson4sSupportTest {
                             with PgJson4sSupport
                             with array.PgArrayJdbcTypes {
     /// for json support
+    override val pgjson = "jsonb"
     type DOCType = text.Document
     override val jsonMethods = org.json4s.native.JsonMethods
 
@@ -67,7 +68,7 @@ class PgJson4sSupportTest {
 
       val q11 = JsonTests.filter(_.json.+>>("a") === "101").map(_.json.+>>("c"))
       println(s"[json4s] '+>>' sql = ${q11.selectStatement}")
-      assertEquals("[3,4,5,9]", q11.first)
+      assertEquals("[3,4,5,9]", q11.first.replace(" ", ""))
 
       val q12 = JsonTests.filter(_.json.+>>("a") === "101".bind).map(_.json.+>("c"))
       println(s"[json4s] '+>' sql = ${q12.selectStatement}")
@@ -80,7 +81,7 @@ class PgJson4sSupportTest {
 
       val q21 = JsonTests.filter(_.id === testRec2.id).map(_.json.~>>(1))
       println(s"[json4s] '~>>' sql = ${q21.selectStatement}")
-      assertEquals("""{"a":"v5","b":3}""", q21.first)
+      assertEquals("""{"a":"v5","b":3}""", q21.first.replace(" ", ""))
 
       /* disable it, because operator does not exist: json = json */
 //      val q3 = JsonTests.filter(_.json.#>(List("c")) === parse("[3,4,5,9]")).map(r => r)
@@ -91,7 +92,7 @@ class PgJson4sSupportTest {
       println(s"[json4s] '#>' sql = ${q31.selectStatement}")
       assertEquals(parse("[3,4,5,9]"), q31.first)
 
-      val q4 = JsonTests.filter(_.json.#>>(List("c")) === "[3,4,5,9]").map(r => r)
+      val q4 = JsonTests.filter(_.json.#>>(List("a")) === "101").map(r => r)
       println(s"[json4s] '#>>' sql = ${q4.selectStatement}")
       assertEquals(testRec1, q4.first)
 

--- a/src/test/scala/com/github/tminglei/slickpg/addon/PgPlayJsonSupportTest.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/addon/PgPlayJsonSupportTest.scala
@@ -90,6 +90,10 @@ class PgPlayJsonSupportTest {
       println(s"[play-json] 'arrayElements' sql = ${q41.selectStatement}")
       assertEquals(json1, q41.first)
 
+      val q42 = JsonTests.filter(_.id === testRec2.id).map(_.json.arrayElementsText)
+      println(s"[json] 'arrayElementsText' sql = ${q42.selectStatement}")
+      assertEquals(json1.toString.replace(" ", ""), q42.first.replace(" ", ""))
+
       val q5 = JsonTests.filter(_.id === testRec1.id).map(_.json.objectKeys)
       println(s"[play-json] 'objectKeys' sql = ${q5.selectStatement}")
       assertEquals(List("a","b","c"), q5.list)
@@ -97,6 +101,18 @@ class PgPlayJsonSupportTest {
       val q51 = JsonTests.filter(_.id === testRec1.id).map(_.json.objectKeys)
       println(s"[play-json] 'objectKeys' sql = ${q51.selectStatement}")
       assertEquals("a", q51.first)
+
+      val q6 = JsonTests.filter(_.json @> Json.parse(""" {"b":"aaa"} """)).map(_.id)
+      println(s"[json] '@>' sql = ${q6.selectStatement}")
+      assertEquals(33L, q6.first)
+
+      val q7 = JsonTests.filter(Json.parse(""" {"b":"aaa"} """) <@: _.json).map(_.id)
+      println(s"[json] '<@' sql = ${q7.selectStatement}")
+      assertEquals(33L, q7.first)
+
+      val q8 = JsonTests.filter(_.id === testRec1.id).map(_.json.+>("a").jsonType)
+      println(s"[json] 'typeof' sql = ${q8.selectStatement}")
+      assertEquals("number", q8.first.toLowerCase)
     }
   }
 

--- a/src/test/scala/com/github/tminglei/slickpg/addon/PgPlayJsonSupportTest.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/addon/PgPlayJsonSupportTest.scala
@@ -12,6 +12,7 @@ class PgPlayJsonSupportTest {
   object MyPostgresDriver extends PostgresDriver
                             with PgPlayJsonSupport
                             with array.PgArrayJdbcTypes {
+    override val pgjson = "jsonb"
 
     override lazy val Implicit = new Implicits with JsonImplicits
     override val simple = new Implicits with SimpleQL with JsonImplicits {
@@ -62,7 +63,7 @@ class PgPlayJsonSupportTest {
 
       val q11 = JsonTests.filter(_.json.+>>("a") === "101".bind).map(_.json.+>>("c"))
       println(s"[play-json] '+>>' sql = ${q11.selectStatement}")
-      assertEquals("[3,4,5,9]", q11.first)
+      assertEquals("[3,4,5,9]", q11.first.replace(" ", ""))
 
       val q12 = JsonTests.filter(_.json.+>>("a") === "101".bind).map(_.json.+>("c"))
       println(s"[play-json] '+>' sql = ${q12.selectStatement}")
@@ -75,7 +76,7 @@ class PgPlayJsonSupportTest {
 
       val q21 = JsonTests.filter(_.id === testRec2.id).map(_.json.~>>(1))
       println(s"[play-json] '~>>' sql = ${q21.selectStatement}")
-      assertEquals("""{"a":"v5","b":3}""", q21.first)
+      assertEquals("""{"a":"v5","b":3}""", q21.first.replace(" ", ""))
 
       val q3 = JsonTests.filter(_.id === testRec2.id).map(_.json.arrayLength)
       println(s"[play-json] 'arrayLength' sql = ${q3.selectStatement}")

--- a/src/test/scala/com/github/tminglei/slickpg/addon/PgSprayJsonSupportTest.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/addon/PgSprayJsonSupportTest.scala
@@ -90,6 +90,10 @@ class PgSprayJsonSupportTest {
       println(s"[spray-json] 'arrayElements' sql = ${q41.selectStatement}")
       assertEquals(json1, q41.first)
 
+      val q42 = JsonTests.filter(_.id === testRec2.id).map(_.json.arrayElementsText)
+      println(s"[json] 'arrayElementsText' sql = ${q42.selectStatement}")
+      assertEquals(json1.toString.replace(" ", ""), q42.first.replace(" ", ""))
+
       val q5 = JsonTests.filter(_.id === testRec1.id).map(_.json.objectKeys)
       println(s"[spray-json] 'objectKeys' sql = ${q5.selectStatement}")
       assertEquals(List("a","b","c"), q5.list)
@@ -97,6 +101,18 @@ class PgSprayJsonSupportTest {
       val q51 = JsonTests.filter(_.id === testRec1.id).map(_.json.objectKeys)
       println(s"[spray-json] 'objectKeys' sql = ${q51.selectStatement}")
       assertEquals("a", q51.first)
+
+      val q6 = JsonTests.filter(_.json @> """ {"b":"aaa"} """.parseJson).map(_.id)
+      println(s"[json] '@>' sql = ${q6.selectStatement}")
+      assertEquals(33L, q6.first)
+
+      val q7 = JsonTests.filter(""" {"b":"aaa"} """.parseJson <@: _.json).map(_.id)
+      println(s"[json] '<@' sql = ${q7.selectStatement}")
+      assertEquals(33L, q7.first)
+
+      val q8 = JsonTests.filter(_.id === testRec1.id).map(_.json.+>("a").jsonType)
+      println(s"[json] 'typeof' sql = ${q8.selectStatement}")
+      assertEquals("number", q8.first.toLowerCase)
     }
   }
 

--- a/src/test/scala/com/github/tminglei/slickpg/addon/PgSprayJsonSupportTest.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/addon/PgSprayJsonSupportTest.scala
@@ -12,6 +12,7 @@ class PgSprayJsonSupportTest {
   object MyPostgresDriver extends PostgresDriver
                             with PgSprayJsonSupport
                             with array.PgArrayJdbcTypes {
+    override val pgjson = "jsonb"
 
     override lazy val Implicit = new Implicits with JsonImplicits
     override val simple = new Implicits with SimpleQL with JsonImplicits {
@@ -62,7 +63,7 @@ class PgSprayJsonSupportTest {
 
       val q11 = JsonTests.filter(_.json.+>>("a") === "101".bind).map(_.json.+>>("c"))
       println(s"[spray-json] '+>>' sql = ${q11.selectStatement}")
-      assertEquals("[3,4,5,9]", q11.first)
+      assertEquals("[3,4,5,9]", q11.first.replace(" ", ""))
 
       val q12 = JsonTests.filter(_.json.+>>("a") === "101".bind).map(_.json.+>("c"))
       println(s"[spray-json] '+>' sql = ${q12.selectStatement}")
@@ -75,7 +76,7 @@ class PgSprayJsonSupportTest {
 
       val q21 = JsonTests.filter(_.id === testRec2.id).map(_.json.~>>(1))
       println(s"[spray-json] '~>>' sql = ${q21.selectStatement}")
-      assertEquals("""{"a":"v5","b":3}""", q21.first)
+      assertEquals("""{"a":"v5","b":3}""", q21.first.replace(" ", ""))
 
       val q3 = JsonTests.filter(_.id === testRec2.id).map(_.json.arrayLength)
       println(s"[spray-json] 'arrayLength' sql = ${q3.selectStatement}")


### PR DESCRIPTION
1) Add jsonb support
2) Add more json operators/functions support

**Note: to keep compatible, `jsonb` support is not on by default.**

You can enable it with config like this:
```scala
trait MyPostgresDriver extends ExPostgresDriver
                          ...
                          with PgJsonSupport
                          with PgSearchSupport {
  override val pgjson = "jsonb"
  ...
```