### PR TITLE
Upgrade to json4s 3.2.11

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,7 +57,7 @@ object SlickPgBuild extends Build {
       </developers>
     )
   )
-  
+
   def mainDependencies(scalaVersion: String) = {
     val extractedLibs = CrossVersion.partialVersion(scalaVersion) match {
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
@@ -90,9 +90,9 @@ object SlickPgBuild extends Build {
         "joda-time" % "joda-time" % "2.4" % "provided",
         "org.joda" % "joda-convert" % "1.7" % "provided",
         "org.threeten" % "threetenbp" % "1.0" % "provided",
-        "org.json4s" %% "json4s-ast" % "3.2.10" % "provided",
-        "org.json4s" %% "json4s-core" % "3.2.10" % "provided",
-        "org.json4s" %% "json4s-native" % "3.2.10" % "test",
+        "org.json4s" %% "json4s-ast" % "3.2.11" % "provided",
+        "org.json4s" %% "json4s-core" % "3.2.11" % "provided",
+        "org.json4s" %% "json4s-native" % "3.2.11" % "test",
         "com.typesafe.play" %% "play-json" % "2.3.0" % "provided",
         "io.spray" %%  "spray-json" % "1.3.1" % "provided",
         "io.argonaut" %% "argonaut" % "6.0.4" % "provided",


### PR DESCRIPTION
There's a binary incompatibility in the render() method between json4s 3.2.10 and 3.2.11 json4s/json4s#212 

Other major libraries like spray are already using json4s 3.2.11, which makes it difficult to use them alongside slick-pg because of this incompatibility.  Can you do a quick release upgrading to json4s 3.2.11?  It has no impact on the functionality you are using, there is just a change of render method signature where the new implicit parameter is supplied a default value, so it won't break any slick-pg code.