### PR TITLE
Ability to map case classes on Range columns

### DIFF
--- a/src/main/scala/com/github/tminglei/slickpg/PgRangeSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgRangeSupport.scala
@@ -45,13 +45,22 @@ trait PgRangeSupport extends range.PgRangeExtensions with utils.PgCommonJdbcType
     implicit val simpleTimestampRangeTypeMapper = new GenericJdbcType[Range[Timestamp]]("tsrange", mkRangeFn(toTimestamp))
     implicit val simpleDateRangeTypeMapper = new GenericJdbcType[Range[Date]]("daterange", mkRangeFn(toSQLDate))
 
+
     implicit def simpleRangeColumnExtensionMethods[B0](c: Rep[Range[B0]])(
       implicit tm: JdbcType[B0], tm1: JdbcType[Range[B0]]) = {
         new RangeColumnExtensionMethods[Range[B0], B0, Range[B0]](c)
       }
+    implicit def simpleRangeMappedColumnExtensionMethods[B0, P1](c: Rep[P1])(
+      implicit mapper: MappedJdbcType[P1, Range[B0]], tm: JdbcType[B0], tm1: JdbcType[Range[B0]]) = {
+        new RangeColumnExtensionMethods[P1, B0, P1](c)
+      }
     implicit def simpleRangeOptionColumnExtensionMethods[B0](c: Rep[Option[Range[B0]]])(
       implicit tm: JdbcType[B0], tm1: JdbcType[Range[B0]]) = {
         new RangeColumnExtensionMethods[Range[B0], B0, Option[Range[B0]]](c)
+      }
+    implicit def simpleRangeOptionMappedColumnExtensionMethods[B0, P1](c: Rep[Option[P1]])(
+      implicit mapper: MappedJdbcType[P1, Range[B0]], tm: JdbcType[B0], tm1: JdbcType[Range[B0]]) = {
+        new RangeColumnExtensionMethods[P1, B0, Option[P1]](c)
       }
   }
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgRangeSupportTest.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgRangeSupportTest.scala
@@ -3,42 +3,61 @@ package com.github.tminglei.slickpg
 import org.junit._
 import org.junit.Assert._
 import java.sql.Timestamp
-import slick.jdbc.GetResult
+import slick.jdbc.{SetParameter, PositionedParameters, GetResult}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class PgRangeSupportTest {
   import MyPostgresDriver.api._
+  import MyPostgresDriver.MappedJdbcType
 
   val db = Database.forURL(url = dbUrl, driver = "org.postgresql.Driver")
 
   val tsFormatter = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
   def ts(str: String) = new Timestamp(tsFormatter.parse(str).getTime)
 
+  case class CustomRange(
+    from:Timestamp, 
+    to:Timestamp)
+  object CustomRange {
+    def apply(r: Range[Timestamp]): CustomRange = CustomRange(r.start, r.end)
+  }
+
   case class RangeBean(
     id: Long,
     intRange: Range[Int],
     floatRange: Range[Float],
-    tsRange: Option[Range[Timestamp]]
-    )
+    tsRange: Option[Range[Timestamp]],
+    customRange: CustomRange)
+
+  implicit val CustomRangeType = MappedColumnType.base[CustomRange, Range[Timestamp]](
+    { case CustomRange(from, to) => Range(from, to, `[_,_)`) },
+    { case Range(from, to, `[_,_)`) => CustomRange(from, to) })
+    // MappedColumnType.base returns a 'BaseColumnType[T]', but it's actually a 'MappedJdbcType[T, U] with BaseTypedType[T]'
+    .asInstanceOf[MappedJdbcType[CustomRange, Range[Timestamp]]]
 
   class RangeTestTable(tag: Tag) extends Table[RangeBean](tag, "RangeTest") {
+
     def id = column[Long]("id", O.AutoInc, O.PrimaryKey)
     def intRange = column[Range[Int]]("int_range", O.Default(Range(3, 5)))
     def floatRange = column[Range[Float]]("float_range")
     def tsRange = column[Option[Range[Timestamp]]]("ts_range")
+    def customRange = column[CustomRange]("custom_range")
 
-    def * = (id, intRange, floatRange, tsRange) <> (RangeBean.tupled, RangeBean.unapply)
+    def * = (id, intRange, floatRange, tsRange, customRange) <> (RangeBean.tupled, RangeBean.unapply)
   }
   val RangeTests = TableQuery[RangeTestTable]
 
   //-------------------------------------------------------------------------------
 
   val testRec1 = RangeBean(33L, Range(3, 5), Range(1.5f, 3.3f),
-    Some(Range(ts("2010-01-01 14:30:00"), ts("2010-01-03 15:30:00"))))
+    Some(Range(ts("2010-01-01 14:30:00"), ts("2010-01-03 15:30:00"))),
+    CustomRange(ts("2010-01-01 14:30:00"), ts("2010-03-01 14:30:00")))
   val testRec2 = RangeBean(35L, Range(31, 59), Range(11.5f, 33.3f),
-    Some(Range(ts("2011-01-01 14:30:00"), ts("2011-11-01 15:30:00"))))
-  val testRec3 = RangeBean(41L, Range(1, 5), Range(7.5f, 15.3f), None)
+    Some(Range(ts("2011-01-01 14:30:00"), ts("2011-11-01 15:30:00"))),
+    CustomRange(ts("2011-01-01 14:30:00"), ts("2011-03-01 14:30:00")))
+  val testRec3 = RangeBean(41L, Range(1, 5), Range(7.5f, 15.3f), None,
+    CustomRange(ts("2012-01-01 14:30:00"), ts("2012-03-01 14:30:00")))
 
   @Test
   def testRangeFunctions(): Unit = {
@@ -49,6 +68,9 @@ class PgRangeSupportTest {
       // 0. '@>'/'<@'/'&&'
       RangeTests.filter(_.tsRange @>^ ts("2011-10-01 15:30:00")).sortBy(_.id).to[List].result.map(
         assertEquals(List(testRec2), _)
+      ),
+      RangeTests.filter(_.customRange @>^ ts("2011-10-01 15:30:00")).sortBy(_.id).to[List].result.map(
+        assertEquals(List(testRec2, testRec3), _)
       ),
       RangeTests.filter(ts("2011-10-01 15:30:00").bind <@^: _.tsRange).sortBy(_.id).to[List].result.map(
         assertEquals(List(testRec2), _)
@@ -108,19 +130,27 @@ class PgRangeSupportTest {
     import MyPlainPostgresDriver.plainAPI._
 
     implicit val getRangeBeanResult = GetResult(r =>
-      RangeBean(r.nextLong(), r.nextIntRange(), r.nextFloatRange(), r.nextTimestampRangeOption()))
+      RangeBean(r.nextLong(), r.nextIntRange(), r.nextFloatRange(), r.nextTimestampRangeOption(), CustomRange(r.nextTimestampRange())))
 
-    val b = RangeBean(33L, Range(3, 5), Range(1.5f, 3.3f), Some(Range(ts("2010-01-01 14:30:00"), ts("2010-01-03 15:30:00"))))
+    val b = RangeBean(33L, Range(3, 5), Range(1.5f, 3.3f), 
+                      Some(Range(ts("2010-01-01 14:30:00"), ts("2010-01-03 15:30:00"))),
+                      CustomRange(ts("2015-01-01 14:30:00"), ts("2015-03-01 14:30:00")))
+
+    implicit object SetCustomRange extends SetParameter[CustomRange] {
+      def apply(v: CustomRange, pp: PositionedParameters) = 
+        pp.setObject(utils.mkPGobject("daterange", v.toString), java.sql.Types.OTHER)
+    }
 
     db.run(DBIO.seq(
       sqlu"""create table RangeTest(
             |  id int8 not null primary key,
             |  int_range int4range not null,
             |  float_range numrange not null,
-            |  ts_range tsrange)
+            |  ts_range tsrange,
+            |  custom_range tsrange not null)
           """,
       ///
-      sqlu"insert into RangeTest values(${b.id}, ${b.intRange}, ${b.floatRange}, ${b.tsRange})",
+      sqlu"insert into RangeTest values(${b.id}, ${b.intRange}, ${b.floatRange}, ${b.tsRange}, ${b.customRange})",
       sql"select * from RangeTest where id = ${b.id}".as[RangeBean].head.map(
         assertEquals(b, _)
       ),


### PR DESCRIPTION
Hi 涂名雷,

As said on Typesafe's blog by Dick Wall (https://typesafe.com/blog/type-early-type-often), one may want to use case classes rather than basic types to make his code more type safe. 

I'm trying to define a case class and to map it to Range. 

Given the following case class : `case class CustomRange(from:Timestamp, to:Timestamp)`, I have a working solution but it requires a bit of a hugly hack.

Here is the mapping : 
```scala
implicit val CustomRangeType = MappedColumnType.base[CustomRange, Range[Timestamp]](
    { case CustomRange(from, to) => Range(from, to, `[_,_)`) },
    { case Range(from, to, `[_,_)`) => CustomRange(from, to) })
    .asInstanceOf[MappedJdbcType[CustomRange, Range[Timestamp]]]
```

The `.asInstanceOf[]` part comes from here: `MappedColumnType.base()` returns a `BaseColumnType[T]`, but it's actually a `MappedJdbcType[T, U] with BaseTypedType[T]` see: https://github.com/slick/slick/blob/883435050da236e2c3229ee11489dd0e28911d3b/slick/src/main/scala/slick/driver/JdbcTypesComponent.scala#L45

I haven't been able to figure out a better solution. Maybe we can talk with Stefan Zeiger to change the return type of `MappedColumnType.base()` ?

What do you think ?

best
Nicolas




