### PR TITLE
Add date/timestamp values "infinity" and "-infinity" to threeten support

### DIFF
--- a/src/test/scala/com/github/tminglei/slickpg/addon/PgDate2SupportTest.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/addon/PgDate2SupportTest.scala
@@ -30,7 +30,8 @@ class PgDate2SupportTest {
     date: LocalDate,
     time: LocalTime,
     dateTime: LocalDateTime,
-    dateTimetz: ZonedDateTime,
+    dateTimeOffset: OffsetDateTime,
+    dateTimeTz: ZonedDateTime,
     duration: Duration,
     period: Period
     )
@@ -39,25 +40,28 @@ class PgDate2SupportTest {
     def id = column[Long]("id", O.AutoInc, O.PrimaryKey)
     def date = column[LocalDate]("date")
     def time = column[LocalTime]("time")
-    def datetime = column[LocalDateTime]("datetime")
-    def dateTimetz = column[ZonedDateTime]("dateTimetz")
+    def dateTime = column[LocalDateTime]("dateTime")
+    def dateTimeOffset = column[OffsetDateTime]("dateTimeOffset")
+    def dateTimeTz = column[ZonedDateTime]("dateTimeTz")
     def duration = column[Duration]("duration")
     def period = column[Period]("period")
 
-    def * = (id, date, time, datetime, dateTimetz, duration, period) <> (DatetimeBean.tupled, DatetimeBean.unapply)
+    def * = (id, date, time, dateTime, dateTimeOffset, dateTimeTz, duration, period) <> (DatetimeBean.tupled, DatetimeBean.unapply)
   }
   val Datetimes = TableQuery[DatetimeTable]
 
   //------------------------------------------------------------------------------
 
   val testRec1 = new DatetimeBean(101L, LocalDate.parse("2010-11-03"), LocalTime.parse("12:33:01.101357"),
-    LocalDateTime.parse("2001-01-03T13:21:00.223571"), ZonedDateTime.parse("2001-01-03 13:21:00.102203+08", date2TzDateTimeFormatter),
+    LocalDateTime.parse("2001-01-03T13:21:00.223571"),
+    OffsetDateTime.parse("2001-01-03 13:21:00.102203+08", date2TzDateTimeFormatter),
+    ZonedDateTime.parse("2001-01-03 13:21:00.102203+08", date2TzDateTimeFormatter),
     Duration.parse("P1DT1H1M0.335701S"), Period.parse("P1Y2M3W4D"))
-  val testRec2 = new DatetimeBean(102L, LocalDate.parse("2011-03-02"), LocalTime.parse("03:14:07"),
-    LocalDateTime.parse("2012-05-08T11:31:06"), ZonedDateTime.parse("2012-05-08 11:31:06.003-05", date2TzDateTimeFormatter),
+  val testRec2 = new DatetimeBean(102L, LocalDate.MAX, LocalTime.parse("03:14:07"),
+    LocalDateTime.MAX, LocalDateTime.MAX.atOffset(ZoneOffset.UTC), LocalDateTime.MAX.atZone(ZoneId.of("UTC")),
     Duration.parse("P1587D"), Period.parse("P15M7D"))
-  val testRec3 = new DatetimeBean(103L, LocalDate.parse("2000-05-19"), LocalTime.parse("11:13:34"),
-    LocalDateTime.parse("2019-11-03T13:19:03"), ZonedDateTime.parse("2019-11-03 13:19:03+03", date2TzDateTimeFormatter),
+  val testRec3 = new DatetimeBean(103L, LocalDate.MIN, LocalTime.parse("11:13:34"),
+    LocalDateTime.MIN, LocalDateTime.MIN.atOffset(ZoneOffset.UTC), LocalDateTime.MIN.atZone(ZoneId.of("UTC")),
     Duration.parse("PT63H16M2S"), Period.parse("P3M5D"))
 
   @Test
@@ -72,8 +76,18 @@ class PgDate2SupportTest {
         // testRec2 and testRec3 will fail to equal test, because of different time zone
         assertEquals(testRec1/*List(testRec1, testRec2, testRec3)*/, _)
       ),
-      Datetimes.filter(_.id === 101L.bind).map { r => (r.date.isFinite, r.datetime.isFinite, r.duration.isFinite) }.result.head.map(
+      Datetimes.filter(_.id === 101L.bind).map { r => (r.date.isFinite, r.dateTime.isFinite, r.duration.isFinite) }.result.head.map(
         assertEquals((true, true, true), _)
+      ),
+      Datetimes.filter(_.id === 102L.bind).map {
+        r => (r.date.isFinite, r.dateTime.isFinite, r.dateTimeOffset.isFinite, r.dateTimeTz.isFinite)
+      }.result.head.map(
+        assertEquals((false, false, false, false), _)
+      ),
+      Datetimes.filter(_.id === 103L.bind).map {
+        r => (r.date.isFinite, r.dateTime.isFinite, r.dateTimeOffset.isFinite, r.dateTimeTz.isFinite)
+      }.result.head.map(
+        assertEquals((false, false, false, false), _)
       ),
       // 1. '+'
       Datetimes.filter(_.id === 101L.bind).map(r => r.date + r.time).result.head.map(
@@ -88,7 +102,7 @@ class PgDate2SupportTest {
       Datetimes.filter(_.id === 101L.bind).map(r => r.time +++ r.duration).result.head.map(
         assertEquals(LocalTime.parse("13:34:01.437058"), _)
       ),
-      Datetimes.filter(_.id === 101L.bind).map(r => r.datetime +++ r.duration).result.head.map(
+      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTime +++ r.duration).result.head.map(
         assertEquals(LocalDateTime.parse("2001-01-04T14:22:00.559272"), _)
       ),
       Datetimes.filter(_.id === 101L.bind).map(r => r.date ++ 7.bind).result.head.map(
@@ -98,13 +112,13 @@ class PgDate2SupportTest {
       Datetimes.filter(_.id === 101L.bind).map(r => r.date -- 1.bind).result.head.map(
         assertEquals(LocalDate.parse("2010-11-02"), _)
       ),
-      Datetimes.filter(_.id === 101L.bind).map(r => r.datetime -- r.time).result.head.map(
+      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTime -- r.time).result.head.map(
         assertEquals(LocalDateTime.parse("2001-01-03T00:47:59.122214"), _)
       ),
-      Datetimes.filter(_.id === 101L.bind).map(r => r.datetime - r.date).result.head.map(
+      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTime - r.date).result.head.map(
         assertEquals(Duration.parse("-P3590DT10H39M").plus(Duration.parse("PT0.223571S")), _)
       ),
-      Datetimes.filter(_.id === 101L.bind).map(r => r.date.asColumnOf[LocalDateTime] - r.datetime).result.head.map(
+      Datetimes.filter(_.id === 101L.bind).map(r => r.date.asColumnOf[LocalDateTime] - r.dateTime).result.head.map(
         assertEquals(Duration.parse("P3590DT10H38M59.776429S"), _)
       ),
       Datetimes.filter(_.id === 101L.bind).map(r => r.date - LocalDate.parse("2009-07-05")).result.head.map(
@@ -113,7 +127,7 @@ class PgDate2SupportTest {
       Datetimes.filter(_.id === 101L.bind).map(r => r.time - LocalTime.parse("02:37:00").bind).result.head.map(
         assertEquals(Duration.parse("PT9H56M1.101357S"), _)
       ),
-      Datetimes.filter(_.id === 101L.bind).map(r => r.datetime --- r.duration).result.head.map(
+      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTime --- r.duration).result.head.map(
         assertEquals(LocalDateTime.parse("2001-01-02T12:19:59.887870"), _)
       ),
       Datetimes.filter(_.id === 101L.bind).map(r => r.time --- r.duration).result.head.map(
@@ -123,18 +137,18 @@ class PgDate2SupportTest {
         assertEquals(LocalDateTime.parse("2010-11-01T22:58:59.664299"), _)
       ),
       // 3. 'age'
-      Datetimes.filter(_.id === 101L.bind).map(r => r.datetime.age === r.datetime.age(Functions.currentDate.asColumnOf[LocalDateTime])).result.head.map(
+      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTime.age === r.dateTime.age(Functions.currentDate.asColumnOf[LocalDateTime])).result.head.map(
         assertEquals(true, _)
       ),
       // 4. 'part'
-      Datetimes.filter(_.id === 101L.bind).map(r => r.datetime.part("year")).result.head.map(
+      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTime.part("year")).result.head.map(
         assertEquals(2001, _, 0.00001d)
       ),
       Datetimes.filter(_.id === 102L.bind).map(r => r.duration.part("year")).result.head.map(
         assertEquals(0, _, 0.00001d)
       ),
       // 5. 'trunc'
-      Datetimes.filter(_.id === 101L.bind).map(r => r.datetime.trunc("day")).result.head.map(
+      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTime.trunc("day")).result.head.map(
         assertEquals(LocalDateTime.parse("2001-01-03T00:00:00"), _)
       ),
       // 6. interval
@@ -166,14 +180,23 @@ class PgDate2SupportTest {
         assertEquals(Duration.parse("P2DT15H16M2S"), _)
       ),
       // timestamp with time zone
-      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTimetz.age === r.dateTimetz.age(Functions.currentDate.asColumnOf[ZonedDateTime])).result.head.map(
+      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTimeTz.age === r.dateTimeTz.age(Functions.currentDate.asColumnOf[ZonedDateTime])).result.head.map(
         assertEquals(true, _)
       ),
-      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTimetz.part("year")).result.head.map(
+      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTimeTz.part("year")).result.head.map(
         assertEquals(2001, _, 0.00001d)
       ),
-      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTimetz.trunc("day")).result.head.map(
+      Datetimes.filter(_.id === 101L.bind).map(r => r.dateTimeTz.trunc("day")).result.head.map(
         assertEquals(ZonedDateTime.parse("2001-01-03 00:00:00+08", date2TzDateTimeFormatter), _)
+      ),
+      // 8. +/-infinity
+      Datetimes.filter(_.id === 102L.bind).map { r => (r.date, r.dateTime, r.dateTimeOffset, r.dateTimeTz) }.result.head.map(
+        assertEquals((LocalDate.MAX, LocalDateTime.MAX,
+          LocalDateTime.MAX.atOffset(ZoneOffset.UTC), LocalDateTime.MAX.atZone(ZoneId.of("UTC"))), _)
+      ),
+      Datetimes.filter(_.id === 103L.bind).map { r => (r.date, r.dateTime, r.dateTimeOffset, r.dateTimeTz) }.result.head.map(
+        assertEquals((LocalDate.MIN, LocalDateTime.MIN,
+          LocalDateTime.MIN.atOffset(ZoneOffset.UTC), LocalDateTime.MIN.atZone(ZoneId.of("UTC"))), _)
       ),
       ///
       Datetimes.schema drop
@@ -187,11 +210,13 @@ class PgDate2SupportTest {
     import MyPostgresDriver.plainAPI._
 
     implicit val getDateBean = GetResult(r => DatetimeBean(
-      r.nextLong(), r.nextLocalDate(), r.nextLocalTime(), r.nextLocalDateTime(), r.nextZonedDateTime(),
+      r.nextLong(), r.nextLocalDate(), r.nextLocalTime(), r.nextLocalDateTime(), r.nextOffsetDateTime(), r.nextZonedDateTime(),
       r.nextDuration(), r.nextPeriod()))
 
     val b = new DatetimeBean(107L, LocalDate.parse("2010-11-03"), LocalTime.parse("12:33:01.101357"),
-      LocalDateTime.parse("2001-01-03T13:21:00.223571"), ZonedDateTime.parse("2001-01-03 13:21:00.102203+08", date2TzDateTimeFormatter),
+      LocalDateTime.parse("2001-01-03T13:21:00.223571"),
+      OffsetDateTime.parse("2001-01-03 13:21:00.102203+08", date2TzDateTimeFormatter),
+      ZonedDateTime.parse("2001-01-03 13:21:00.102203+08", date2TzDateTimeFormatter),
       Duration.parse("P1DT1H1M0.335701S"), Period.parse("P1Y2M3W4D"))
 
     Await.result(db.run(DBIO.seq(
@@ -200,13 +225,14 @@ class PgDate2SupportTest {
               date date not null,
               time time not null,
               ts timestamp not null,
+              tsos timestamptz not null,
               tstz timestamptz not null,
               duration interval not null,
               period interval not null)
           """,
       sqlu"SET TIMEZONE TO '+8';",
       ///
-      sqlu"insert into Datetime2Test values(${b.id}, ${b.date}, ${b.time}, ${b.dateTime}, ${b.dateTimetz}, ${b.duration}, ${b.period})",
+      sqlu"insert into Datetime2Test values(${b.id}, ${b.date}, ${b.time}, ${b.dateTime}, ${b.dateTimeOffset}, ${b.dateTimeTz}, ${b.duration}, ${b.period})",
       sql"select * from Datetime2Test where id = ${b.id}".as[DatetimeBean].head.map(
         assertEquals(b, _)
       ),


### PR DESCRIPTION
PostgreSQL supports two special date/time input values: `infinity` and `-infinity`, which are respectively later and earlier than all other time stamps.  See [manual section 8.5.1.4, Special Date/Time Values](http://www.postgresql.org/docs/9.4/interactive/datatype-datetime.html#AEN6039)

Currently, if slick-pg receives one of these values from a server it fails with an exception.  This patch adds the relevant support to slick-pg's `java.time` (three-ten) support features.  When these values are received from a server, they are interpreted as being one of the maximum or minimum possible `Date`, `LocalDateTime`, `OffsetDateTime` or `ZonedDateTime` values as defined by constants in the Java library, using UTC for types that represent offsets or timezones.

Conversely, when such a minimum- or maximum date value is sent to a server, the mapper will convert it to the appropriate +/-infinity value.

This patch includes tests, and also some changes to the tests suite.  In particular there were no tests for `OffsetDateTime` so I changed the schema of the table used for testing by adding a column.  I also made some minor changes to inconsistent capitalization in variable names.