### PR TITLE
Add support for java.time.ZoneId

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -67,7 +67,7 @@ object SlickPgBuild extends Build {
     }
     Seq (
       "org.scala-lang" % "scala-reflect" % scalaVersion,
-      "com.typesafe.slick" %% "slick" % "3.0.0-RC1",
+      "com.typesafe.slick" %% "slick" % "3.0.0-RC2",
       "org.postgresql" % "postgresql" % "9.4-1201-jdbc41",
       "junit" % "junit" % "4.11" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test"

--- a/src/main/scala/com/github/tminglei/slickpg/addon/PgDate2Support.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/addon/PgDate2Support.scala
@@ -99,6 +99,7 @@ trait PgDate2Support extends date.PgDateExtensions with utils.PgCommonJdbcTypes 
       fromOffsetDateTimeOrInfinity, toOffsetDateTimeOrInfinity, hasLiteralForm=false)
     implicit val date2TzTimestamp1TypeMapper = new GenericJdbcType[ZonedDateTime]("timestamptz",
       fromZonedDateTimeOrInfinity, toZonedDateTimeOrInfinity, hasLiteralForm=false)
+    implicit val date2ZoneMapper = new GenericJdbcType[ZoneId]("text", ZoneId.of(_), _.getId, hasLiteralForm=false)
 
     ///
     implicit def date2DateColumnExtensionMethods(c: Rep[LocalDate])(implicit tm: JdbcType[INTERVAL]) =
@@ -176,6 +177,8 @@ trait PgDate2Support extends date.PgDateExtensions with utils.PgCommonJdbcTypes 
       def nextPeriodOption() = r.nextStringOption().map(pgIntervalStr2Period)
       def nextDuration() = nextDurationOption().orNull
       def nextDurationOption() = r.nextStringOption().map(pgIntervalStr2Duration)
+      def nextZoneId() = nextZoneIdOption().orNull
+      def nextZoneIdOption() = r.nextStringOption().map(ZoneId.of)
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -233,6 +236,13 @@ trait PgDate2Support extends date.PgDateExtensions with utils.PgCommonJdbcTypes 
     }
     implicit object SetDurationOption extends SetParameter[Option[Duration]] {
       def apply(v: Option[Duration], pp: PositionedParameters) = setDateTime(Types.OTHER, "interval", v.map(_.toString), pp)
+    }
+    ///
+    implicit object SetZone extends SetParameter[ZoneId] {
+      def apply(v: ZoneId, pp: PositionedParameters) = setDateTime(Types.VARCHAR, "text", Option(v).map(_.toString), pp)
+    }
+    implicit object SetZoneOption extends SetParameter[Option[ZoneId]] {
+      def apply(v: Option[ZoneId], pp: PositionedParameters) = setDateTime(Types.VARCHAR, "text", v.map(_.toString), pp)
     }
 
     ///


### PR DESCRIPTION
This patch adds support for the [java.time.ZoneId](http://docs.oracle.com/javase/8/docs/api/index.html?java/time/ZoneId.html) class.  PosgreSQL does not have a native timezone type, but it does know about timezones, and [DBAs can create an SQL domain that simulates such a type](http://justatheory.com/computers/databases/postgresql/timezone_validation.html).  This code causes the DDL to create a timezone column as PosgreSQL-type `text`.

This patch modifies the test by adding a column for storing and retrieving a timezone.

It also bumps up the Slick version to reflect the latest v3 release candidate.