### PR TITLE
Fixes documentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ trait MyPostgresDriver extends ExPostgresDriver
                           with PgPostGISSupport 
                           with PgNetSupport 
                           with PgLTreeSupport {
-  override val pgjson = "jsonb" //to keep back compatibility, pgjson's value was "json" by default
+  def pgjson = "jsonb" // jsonb support is in postgres 9.4.0 onward; for 9.3.x use "json"
 
   override val api = MyAPI
 


### PR DESCRIPTION
Using `val` causes the error described in this issue (https://github.com/tminglei/slick-pg/issues/141). Switching it from `val` to `def` fixed it for me.