### PR TITLE
Bump play-slick version in Play example

### DIFF
--- a/examples/play-slick-example/build.sbt
+++ b/examples/play-slick-example/build.sbt
@@ -10,7 +10,7 @@ description := "slick-pg play integration example project"
 
 libraryDependencies ++= Seq(
   specs2,
-  "com.typesafe.play" %% "play-slick" % "1.0.0",
+  "com.typesafe.play" %% "play-slick" % "1.0.1",
   "com.typesafe.play" %% "play-slick-evolutions" % "1.0.0",
   "com.github.tminglei" %% "slick-pg" % "0.9.0",
   "org.postgresql" % "postgresql" % "9.4-1201-jdbc41",


### PR DESCRIPTION
This will pull in Slick version `3.0.1`, which contains a fix for the custom Postgres driver failing to load when running Play in dev mode.

Fixes #199 