### PR TITLE
Implementation for orderedIndex

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Slick-pg
 - Inet/MacAddr
 - `text` Search
 - `postgis` Geometry
+- Postgres specific index's (such as ordered index's)
 
 #### Currently supported pg features:
 - inherits
@@ -172,6 +173,7 @@ Details
 - Search's [oper/functions](https://github.com/tminglei/slick-pg/tree/master/core/src/main/scala/com/github/tminglei/slickpg/search "Search's oper/functions"), usage [cases](https://github.com/tminglei/slick-pg/blob/master/src/test/scala/com/github/tminglei/slickpg/PgSearchSupportSuite.scala "test cases")
 - Geometry's [oper/functions](https://github.com/tminglei/slick-pg/tree/master/core/src/main/scala/com/github/tminglei/slickpg/geom "Geometry's oper/functions"), usage cases for [postgis](https://github.com/tminglei/slick-pg/blob/master/addons/jts/src/test/scala/com/github/tminglei/slickpg/PgPostGISSupportSuite.scala "test cases")
 - `basic` Composite type [support](https://github.com/tminglei/slick-pg/tree/master/core/src/main/scala/com/github/tminglei/slickpg/composite "Composite type Support"), usage [cases](https://github.com/tminglei/slick-pg/blob/master/src/test/scala/com/github/tminglei/slickpg/PgCompositeSupportSuite.scala "test cases")
+- Postgres Specific Index's [oper/functions] (https://github.com/tminglei/slick-pg/tree/master/core/src/main/scala/com/github/tminglei/slickpg/index "Index Support"), usage [cases](https://github.com/tminglei/slick-pg/blob/master/src/test/scala/com/github/tminglei/slickpg/IndexSupportSuite.scala "test cases")
 
 
 

--- a/core/src/main/scala/com/github/tminglei/slickpg/index/PgIndexExtensions.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/index/PgIndexExtensions.scala
@@ -1,0 +1,24 @@
+package com.github.tminglei.slickpg
+package index
+
+import slick.ast.Node
+import slick.driver.{PostgresDriver, JdbcTypesComponent}
+import slick.lifted._
+
+class OrderedIndex(override val name: String,
+                   override val table: AbstractTable[_],
+                   override val on: IndexedSeq[Node],
+                   val ordering: slick.ast.Ordering, override val unique: Boolean) extends Index(name, table, on, unique)
+
+
+trait PgIndexExtensions extends JdbcTypesComponent { driver: PostgresDriver =>
+
+  import driver.api._
+
+  trait AbstractTableIndexExtensions[T <: AbstractTable[_]] { this: AbstractTable[_] =>
+    /** Define an ordered index or a ordered unique constraint. */
+    def orderedIndex[T](name: String, on: T, ordering: slick.ast.Ordering, unique: Boolean = false)(implicit shape: Shape[_ <: slick.lifted.FlatShapeLevel, T, _, _]) = new OrderedIndex(name, this, ForeignKey.linearizeFieldRefs(shape.toNode(on)), ordering, unique)
+  }
+
+
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,7 +7,7 @@ object SlickPgBuild extends Build {
     organizationName := "slick-pg",
     organization := "com.github.tminglei",
     name := "slick-pg",
-    version := "0.10.2",
+    version := "0.10.3-SNAPSHOT",
 
     scalaVersion := "2.11.7",
     crossScalaVersions := Seq("2.11.7", "2.10.6"),

--- a/src/main/scala/com/github/tminglei/slickpg/PgIndexSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgIndexSupport.scala
@@ -1,0 +1,10 @@
+package com.github.tminglei.slickpg
+
+import com.github.tminglei.slickpg.index.PgIndexExtensions
+import slick.driver.PostgresDriver
+
+trait PgIndexSupport extends PgIndexExtensions { driver: PostgresDriver =>
+
+}
+
+


### PR DESCRIPTION
Postgres has support for a special index type, called ordered index http://www.postgresql.org/docs/8.3/static/indexes-ordering.html. This pull request adds specific support for this index type, it also uses the same slick ordering (i.e. `slick.ast.Ordering`) to define the order

Tests still need to be done + some documentation, also I am not sure if this will have adverse effects in regards to slick code that needs to use index intentionally
