### PR TITLE
Hope for fix #265

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -89,7 +89,7 @@ object SlickPgBuild extends Build {
       libraryDependencies := mainDependencies(scalaVersion.value)
     )
   ).dependsOn (slickPgCore)
-    .aggregate (slickPgCore, slickPgJoda, slickPgJson4s, slickPgJts, slickPgPlayJson, slickPgSprayJson, slickPgArgonaut, slickPgThreeten, slickPgDate2)
+    .aggregate (slickPgCore, slickPgJoda, slickPgJson4s, slickPgJts, slickPgPlayJson, slickPgSprayJson, slickPgCirceJson, slickPgArgonaut, slickPgThreeten, slickPgDate2)
 
   lazy val slickPgJoda = Project(id = "slick-pg_joda-time", base = file("./addons/joda-time"),
     settings = Defaults.coreDefaultSettings ++ commonSettings ++ Seq(


### PR DESCRIPTION
Add circe module to root project's aggregate to fix #265 . I think it's the reason that the circe-json module is missing in maven repo.