### PR TITLE
Fixing parsing of timestamp with time zone

### DIFF
--- a/addons/date2/src/main/scala/com/github/tminglei/slickpg/PgDate2Support.scala
+++ b/addons/date2/src/main/scala/com/github/tminglei/slickpg/PgDate2Support.scala
@@ -43,6 +43,7 @@ trait PgDate2Support extends date.PgDateExtensions with utils.PgCommonJdbcTypes 
         .append(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
         .optionalStart()
         .appendFraction(ChronoField.NANO_OF_SECOND,0,6,true)
+        .appendOffset("+HH:mm","+00")
         .optionalEnd()
         .toFormatter()
     val date2TzTimeFormatter =


### PR DESCRIPTION
Was throwing a parsing exception when timestamps had time zones and was being used as an Instant.