### PR TITLE
Update examples/play-slick-example to use Play 2.5.1

### DIFF
--- a/examples/play-slick-example/build.sbt
+++ b/examples/play-slick-example/build.sbt
@@ -2,17 +2,20 @@ name := "play-slick-pg"
 
 version := "1.0dev"
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala)
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.8"
 
 description := "slick-pg play integration example project"
 
 libraryDependencies ++= Seq(
   specs2,
-  "com.typesafe.play" %% "play-slick" % "1.0.1",
-  "com.typesafe.play" %% "play-slick-evolutions" % "1.0.0",
-  "com.github.tminglei" %% "slick-pg" % "0.9.0",
+  "com.typesafe.play" %% "play-slick" % "2.0.0",
+  "com.typesafe.play" %% "play-slick-evolutions" % "2.0.0",
+  "com.github.tminglei" %% "slick-pg" % "0.12.1",
+  "com.github.tminglei" %% "slick-pg_date2" % "0.12.1",
+  "com.github.tminglei" %% "slick-pg_play-json" % "0.12.1",
   "org.postgresql" % "postgresql" % "9.4-1201-jdbc41",
   "com.vividsolutions" % "jts" % "1.13"
 )

--- a/examples/play-slick-example/conf/application.conf
+++ b/examples/play-slick-example/conf/application.conf
@@ -14,8 +14,8 @@ application.secret="E27D^[_<Lpt0vjad]de;3;tx3gpRmG4ByofnahOIo9gbsMWut1w3xg[>9W"
 # By convention, the default datasource is named `default`
 slick.dbs.default.driver="util.MyPostgresDriver$"
 slick.dbs.default.db.driver="org.postgresql.Driver"
-slick.dbs.default.db.url="jdbc:postgresql://localhost/test"
-slick.dbs.default.db.user=sa
+slick.dbs.default.db.url="jdbc:postgresql://localhost:5432/slick-pg"
+slick.dbs.default.db.user=ntilwalli
 slick.dbs.default.db.password=""
 
 play.evolutions.db.default.autoApply = true // apply evolutions when app starts

--- a/examples/play-slick-example/conf/application.conf
+++ b/examples/play-slick-example/conf/application.conf
@@ -14,8 +14,8 @@ application.secret="E27D^[_<Lpt0vjad]de;3;tx3gpRmG4ByofnahOIo9gbsMWut1w3xg[>9W"
 # By convention, the default datasource is named `default`
 slick.dbs.default.driver="util.MyPostgresDriver$"
 slick.dbs.default.db.driver="org.postgresql.Driver"
-slick.dbs.default.db.url="jdbc:postgresql://localhost:5432/slick-pg"
-slick.dbs.default.db.user=ntilwalli
+slick.dbs.default.db.url="jdbc:postgresql://localhost/test"
+slick.dbs.default.db.user="sa"
 slick.dbs.default.db.password=""
 
 play.evolutions.db.default.autoApply = true // apply evolutions when app starts

--- a/examples/play-slick-example/conf/logback.xml
+++ b/examples/play-slick-example/conf/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
-    
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/examples/play-slick-example/project/plugins.sbt
+++ b/examples/play-slick-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.1")
 
 // web plugins
 

--- a/examples/play-slick-example/project/plugins.sbt
+++ b/examples/play-slick-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.0")
 
 // web plugins
 


### PR DESCRIPTION
Very basic PR.  I updated the example to use Play 2.5.1 since that's the latest.