### PR TITLE
Update example/play-slick-example to use Play 2.5.1

### DIFF
--- a/examples/play-slick-example/build.sbt
+++ b/examples/play-slick-example/build.sbt
@@ -2,19 +2,22 @@ name := "play-slick-pg"
 
 version := "1.0dev"
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala)
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.8"
 
 description := "slick-pg play integration example project"
 
 libraryDependencies ++= Seq(
   specs2,
-  "com.typesafe.play" %% "play-slick" % "1.0.1",
-  "com.typesafe.play" %% "play-slick-evolutions" % "1.0.0",
-  "com.github.tminglei" %% "slick-pg" % "0.9.0",
   "org.postgresql" % "postgresql" % "9.4-1201-jdbc41",
-  "com.vividsolutions" % "jts" % "1.13"
+  "com.vividsolutions" % "jts" % "1.13",
+  "com.typesafe.play" %% "play-slick" % "2.0.0",
+  "com.typesafe.play" %% "play-slick-evolutions" % "2.0.0",
+  "com.github.tminglei" %% "slick-pg" % "0.12.1",
+  "com.github.tminglei" %% "slick-pg_date2" % "0.12.1",
+  "com.github.tminglei" %% "slick-pg_play-json" % "0.12.1"
 )
 
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"

--- a/examples/play-slick-example/conf/logback.xml
+++ b/examples/play-slick-example/conf/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
-    
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/examples/play-slick-example/project/plugins.sbt
+++ b/examples/play-slick-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.1")
 
 // web plugins
 


### PR DESCRIPTION
Basic PR updating to latest Play and drivers.  Update example/play-slick-example to use Play 2.5.1, update play-slick and play-slick-evolutions to use 2.0.0 and update slick-pg drivers to use 0.12.1.