### PR TITLE
Add support for upsert with tables containing keyword column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,52 +190,52 @@ Install
 -------
 To use `slick-pg` in [sbt](http://www.scala-sbt.org/ "slick-sbt") project, add the following to your project file:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg" % "0.14.2"
+libraryDependencies += "com.github.tminglei" %% "slick-pg" % "0.14.3"
 ```
 
 > If you need `joda-time` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_joda-time" % "0.14.2"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_joda-time" % "0.14.3"
 ```
 
 > If you need `jts` geom support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_jts" % "0.14.2"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_jts" % "0.14.3"
 ```
 
 > If you need `jdk8 date` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_date2" % "0.14.2"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_date2" % "0.14.3"
 ```
 
 > If you need `threeten-bp` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_threeten" % "0.14.2"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_threeten" % "0.14.3"
 ```
 
 > If you need `json4s` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_json4s" % "0.14.2"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_json4s" % "0.14.3"
 ```
 
 > If you need `play-json` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_play-json" % "0.14.2"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_play-json" % "0.14.3"
 ```
 
 > If you need `spray-json` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_spray-json" % "0.14.2"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_spray-json" % "0.14.3"
 ```
 
 > If you need `argonaut json` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_argonaut" % "0.14.2"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_argonaut" % "0.14.3"
 ```
 
 > If you need `circe json` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_circe-json" % "0.14.2"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_circe-json" % "0.14.3"
 ```
 
 
@@ -244,7 +244,7 @@ Or, in [maven](http://maven.apache.org/ "maven") project, you can add `slick-pg`
 <dependency>
     <groupId>com.github.tminglei</groupId>
     <artifactId>slick-pg_2.11</artifactId>
-    <version>0.14.2</version>
+    <version>0.14.3</version>
 </dependency>
 <!-- other addons if necessary -->
 ...

--- a/core/src/main/scala/com/github/tminglei/slickpg/ExPostgresDriver.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/ExPostgresDriver.scala
@@ -100,11 +100,12 @@ trait ExPostgresDriver extends JdbcDriver with PostgresDriver with Logging { dri
       sym.options.contains(ColumnOption.PrimaryKey) || funcDefinedPKs.exists(pk => pk.columns.collect {
         case Select(_, f: FieldSymbol) => f
       }.exists(_.name == sym.name)) }
+    private lazy val insertNames = insertingSyms.map { fs => quoteIdentifier(fs.name) }
     private lazy val pkNames = pkSyms.map { fs => quoteIdentifier(fs.name) }
     private lazy val softNames = softSyms.map { fs => quoteIdentifier(fs.name) }
 
     override def buildInsert: InsertBuilderResult = {
-      val insert = s"insert into $tableName (${insertingSyms.mkString(",")}) values (${insertingSyms.map(_ => "?").mkString(",")})"
+      val insert = s"insert into $tableName (${insertNames.mkString(",")}) values (${insertNames.map(_ => "?").mkString(",")})"
       val onConflict = "on conflict (" + pkNames.mkString(", ") + ")"
       val doSomething = if (softNames.isEmpty) "do nothing" else "do update set " + softNames.map(n => s"$n=EXCLUDED.$n").mkString(",")
       val padding = if (nonPkAutoIncSyms.isEmpty) "" else "where ? is null or ?=?"

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgUpsertSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgUpsertSuite.scala
@@ -227,16 +227,16 @@ class PgUpsertSuite extends FunSuite {
       DBIO.seq(
         (UpsertTests2.schema) create,
         ///
-        UpsertTests forceInsertAll Seq(
+        UpsertTests2 forceInsertAll Seq(
           Bean2(101, 1, 2),
           Bean2(102, 3, 4),
           Bean2(103, 5, 6)
         ),
-        UpsertTests.insertOrUpdate(Bean(101, 1, 7)),
-        UpsertTests.insertOrUpdate(Bean(107, 8, 9))
+        UpsertTests2.insertOrUpdate(Bean(101, 1, 7)),
+        UpsertTests2.insertOrUpdate(Bean(107, 8, 9))
       ).andThen(
         DBIO.seq(
-          UpsertTests.sortBy(_.id).to[List].result.map(
+          UpsertTests2.sortBy(_.id).to[List].result.map(
             r => assert(Seq(
               Bean2(101, 1, 7),
               Bean2(102, 3, 4),

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgUpsertSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgUpsertSuite.scala
@@ -200,7 +200,7 @@ class PgUpsertSuite extends FunSuite {
       ).transactionally
     ), Duration.Inf)
   }
-  
+
   ///---
   case class Bean2(id: Long, start: Int, end: Int)
 
@@ -232,8 +232,8 @@ class PgUpsertSuite extends FunSuite {
           Bean2(102, 3, 4),
           Bean2(103, 5, 6)
         ),
-        UpsertTests2.insertOrUpdate(Bean(101, 1, 7)),
-        UpsertTests2.insertOrUpdate(Bean(107, 8, 9))
+        UpsertTests2.insertOrUpdate(Bean2(101, 1, 7)),
+        UpsertTests2.insertOrUpdate(Bean2(107, 8, 9))
       ).andThen(
         DBIO.seq(
           UpsertTests2.sortBy(_.id).to[List].result.map(

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgUpsertSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgUpsertSuite.scala
@@ -200,4 +200,54 @@ class PgUpsertSuite extends FunSuite {
       ).transactionally
     ), Duration.Inf)
   }
+  
+  ///---
+  case class Bean2(id: Long, start: Int, end: Int)
+
+  class UpsertTestTable2(tag: Tag) extends Table[Bean2](tag, "test_tab_upsert2") {
+    def id = column[Long]("id", O.AutoInc, O.PrimaryKey)
+    def start = column[Int]("start")
+    def end = column[Int]("end")
+
+    def * = (id, start, end) <> (Bean2.tupled, Bean2.unapply)
+  }
+  val UpsertTests2 = TableQuery[UpsertTestTable2]
+
+  //------------------------------------------------------------------------------
+
+  test("native upsert support with keyword columns") {
+    import MyPostgresDriver.api._
+
+    val upsertSql = MyPostgresDriver.compileInsert(UpsertTests2.toNode).upsert.sql
+    println(s"upsert sql: $upsertSql")
+
+    assert(upsertSql.contains("on conflict"))
+
+    Await.result(db.run(
+      DBIO.seq(
+        (UpsertTests2.schema) create,
+        ///
+        UpsertTests forceInsertAll Seq(
+          Bean2(101, 1, 2),
+          Bean2(102, 3, 4),
+          Bean2(103, 5, 6)
+        ),
+        UpsertTests.insertOrUpdate(Bean(101, 1, 7)),
+        UpsertTests.insertOrUpdate(Bean(107, 8, 9))
+      ).andThen(
+        DBIO.seq(
+          UpsertTests.sortBy(_.id).to[List].result.map(
+            r => assert(Seq(
+              Bean2(101, 1, 7),
+              Bean2(102, 3, 4),
+              Bean2(103, 5, 6),
+              Bean2(107, 8, 9)
+            ) === r)
+          )
+        )
+      ).andFinally(
+        (UpsertTests2.schema) drop
+      ).transactionally
+    ), Duration.Inf)
+  }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,7 +7,7 @@ object SlickPgBuild extends Build {
     organizationName := "slick-pg",
     organization := "com.github.tminglei",
     name := "slick-pg",
-    version := "0.14.2",
+    version := "0.14.3",
 
     scalaVersion := "2.11.8",
     crossScalaVersions := Seq("2.11.8", "2.10.6"),


### PR DESCRIPTION
Currently the native upsert generator does not properly quote the column names in all places. As a result any table with a reserved key word (e.g. `end`) as a column name will throw a syntax error when executed:

```
org.postgresql.util.PSQLException: ERROR: syntax error at or near "end"
```

Note the difference between the insert and upsert statements for an insert vs an upsert of `Bean2(100, 1, 2)` as defined in the new test cases but without this change:

```
cala> beanInsert.statements
res2: Iterable[String] = Vector(insert into "test_tab_upsert2" ("id","start","end")  values (?,?,?))

scala> beanUpsert.statements
res3: Iterable[String] = Vector("insert into "test_tab_upsert2" (id,start,end) values (?,?,?) on conflict ("id") do update set "start"=EXCLUDED."start","end"=EXCLUDED."end" ")
```

This change applies the same quoting that is done the primary keys and soft keys to the inserting column names.

After the change the sql syntax becomes:

```
Vector("insert into "test_tab_upsert2" ("id","start","end") values (?,?,?) on conflict ("id") do update set "start"=EXCLUDED."start","end"=EXCLUDED."end" ")
```


