### PR TITLE
Follow up on PostGIS deprecation and add missing function mapping

### DIFF
--- a/core/src/main/scala/com/github/tminglei/slickpg/geom/PgPostGISExtensions.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/geom/PgPostGISExtensions.scala
@@ -184,7 +184,8 @@ trait PgPostGISExtensions extends JdbcTypesComponent { driver: PostgresDriver =>
     val Length3D = new SqlFunction("ST_3DLength")
     val Perimeter = new SqlFunction("ST_Perimeter")
     val Distance = new SqlFunction("ST_Distance")
-    val DistanceSphere = new SqlFunction("ST_Distance_Sphere")
+    val DistanceSphere = new SqlFunction("ST_DistanceSphere")
+    val DistanceSpheroid = new SqlFunction("ST_DistanceSpheroid")
     val MaxDistance = new SqlFunction("ST_MaxDistance")
     val HausdorffDistance = new SqlFunction("ST_HausdorffDistance")
     val LongestLine = new SqlFunction("ST_LongestLine")
@@ -487,6 +488,9 @@ trait PgPostGISExtensions extends JdbcTypesComponent { driver: PostgresDriver =>
       }
     def distanceSphere[P2, R](geom: Rep[P2])(implicit om: o#to[Float, R]) = {
         om.column(GeomLibrary.DistanceSphere, n, geom.toNode)
+      }
+    def distanceSpheroid[P2, R](geom: Rep[P2])(implicit om: o#to[Float, R]) = {
+        om.column(GeomLibrary.DistanceSpheroid, n, geom.toNode)
       }
     def maxDistance[P2, R](geom: Rep[P2])(implicit om: o#to[Float, R]) = {
         om.column(GeomLibrary.MaxDistance, n, geom.toNode)


### PR DESCRIPTION
Hello,

1. `ST_Distance_Sphere` has been deprecated and we should now use `ST_DistanceSphere`

   > Changed: 2.2.0 In prior versions this used to be called ST_Distance_Sphere
  
    http://postgis.net/docs/ST_DistanceSphere.html

2. `ST_DistanceSpheroid` was not mapped.

I don't know how you want to handle this deprecation cases? Shall I add new methods that map on `ST_Distance_Sphere` and `ST_Distance_Spheroid`?