### PR TITLE
Fixed issue with empty byte arrays on large object streams

### DIFF
--- a/core/src/main/scala/com/github/tminglei/slickpg/lobj/LargeObjectStreamingDBIOAction.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/lobj/LargeObjectStreamingDBIOAction.scala
@@ -81,8 +81,11 @@ case class LargeObjectStreamingDBIOAction(largeObjectId: Long, bufferSize: Int =
       val thing = readNextResult(stream)
       val bytes = thing._1
       bytesRead = thing._2
-      context.emit(bytes)
-      count += 1
+      //only emit these bytes if the chunk is nonempty to avoid issues with stream cancellation
+      if (bytes.length > 0) {
+        context.emit(bytes)
+        count += 1
+      }
     }
 
     //if the final bytesRead value was non-positive, close the stream and return a null StreamState


### PR DESCRIPTION
Fixed issue with large object streaming where emitting empty byte arrays could cause a stream to terminate prematurely.

I've found this to only occur when streaming a large object via a chunked response on the Play framework. Apparently this is a feature of Akka HTTP too (if I'm not mistaken). See this issue for more details: https://github.com/playframework/playframework/issues/6750