### PR TITLE
Remove all \u0000 characters in encoded json

### DIFF
--- a/addons/play-json/src/main/scala/com/github/tminglei/slickpg/PgPlayJsonSupport.scala
+++ b/addons/play-json/src/main/scala/com/github/tminglei/slickpg/PgPlayJsonSupport.scala
@@ -27,7 +27,7 @@ trait PgPlayJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTyp
       new GenericJdbcType[JsValue](
         pgjson,
         (v) => Json.parse(v),
-        (v) => Json.stringify(v),
+        (v) => Json.stringify(v).replace("\\u0000", ""),
         hasLiteralForm = false
       )
 


### PR DESCRIPTION
postgres does not allow this character in their json/jsonb types so we need to remove it before it hits the db.

This addresses #347 
