### PR TITLE
Fixed the GenericDateJdbcType when mapping `Option[Duration]` column

### DIFF
--- a/core/src/main/scala/com/github/tminglei/slickpg/date/PgDateJdbcTypes.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/date/PgDateJdbcTypes.scala
@@ -40,7 +40,7 @@ trait PgDateJdbcTypes extends JdbcTypesComponent { driver: PostgresProfile =>
       val value = classTag.runtimeClass match {
         case clazz if clazz == classOf[OffsetDateTime]  => Option(r.getObject(idx, classOf[OffsetDateTime])).map(t => if (t != OffsetDateTime.MAX && t != OffsetDateTime.MIN) t.atZoneSameInstant(TimeZone.getDefault.toZoneId).toOffsetDateTime else t).orNull
         case clazz if clazz == classOf[Instant]         => Option(r.getTimestamp(idx)).map(_.toInstant).orNull
-        case clazz if clazz == classOf[Duration]        => Option(r.getObject(idx, classOf[PGInterval])).map(pgInterval2Duration).orNull
+        case clazz if clazz == classOf[Duration]        => Option(r.getString(idx)).map(new PGInterval(_)).map(pgInterval2Duration).orNull
         case clazz                                      => r.getObject(idx, clazz)
       }
       if (r.wasNull) null.asInstanceOf[T] else value.asInstanceOf[T]


### PR DESCRIPTION
Closes #359

Added a test case with `Option` columns, for the `PgDate2SupportSuite`. 
Without the fix at `GenericDateJdbcType`, you can reproduce the reported error.