### PR TITLE
update codegen-customization example

### DIFF
--- a/examples/codegen-customization/build.sbt
+++ b/examples/codegen-customization/build.sbt
@@ -9,30 +9,32 @@ lazy val root = (project in file("."))
 /** codegen project containing the customized code generator */
 lazy val codegen = project
   .settings(sharedSettings)
-  .settings(libraryDependencies += "com.typesafe.slick" %% "slick-codegen" % "3.1.1")
+  .settings(libraryDependencies += "com.typesafe.slick" %% "slick-codegen" % "3.2.3")
 
 
 // shared sbt config between main project and codegen project
 lazy val sharedSettings = Seq(
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.12.5",
   scalacOptions := Seq("-feature", "-unchecked", "-deprecation"),
   libraryDependencies ++= List(
-    "com.typesafe.slick" %% "slick" % "3.1.1",
-    "org.postgresql" % "postgresql" % "9.4-1201-jdbc41",
-    "com.github.tminglei" %% "slick-pg" % "0.14.1",
-    "com.github.tminglei" %% "slick-pg_play-json" % "0.14.1",
-    "com.github.tminglei" %% "slick-pg_joda-time" % "0.14.1",
-    "com.github.tminglei" %% "slick-pg_jts" % "0.14.1",
-    "joda-time" % "joda-time" % "2.4",
-    "org.joda" % "joda-convert" % "1.7",
+    "com.typesafe.slick" %% "slick" % "3.2.3",
+    "org.postgresql" % "postgresql" % "42.2.2",
+    "com.github.tminglei" %% "slick-pg" % "0.16.0",
+    "com.github.tminglei" %% "slick-pg_play-json" % "0.16.0",
+    "com.github.tminglei" %% "slick-pg_joda-time" % "0.16.0",
+    "com.github.tminglei" %% "slick-pg_jts" % "0.16.0",
+    "joda-time" % "joda-time" % "2.9.9",
+    "org.joda" % "joda-convert" % "2.0.1",
     "com.vividsolutions" % "jts" % "1.13",
-    "org.slf4j" % "slf4j-nop" % "1.7.12"
+    "org.slf4j" % "log4j-over-slf4j" % "1.7.25",
+    "ch.qos.logback" % "logback-core" % "1.2.3",
+    "ch.qos.logback" % "logback-classic" % "1.2.3"
   )
 )
 
 
 // code generation task that calls the customized code generator
-lazy val slick = taskKey[Seq[File]]("gen-tables")
+lazy val slick = taskKey[Seq[File]]("slick")
 lazy val slickCodeGenTask = Def.task {
   val dir = sourceManaged.value
   val cp = (dependencyClasspath in Compile).value

--- a/examples/codegen-customization/codegen/src/main/scala/demo/Config.scala
+++ b/examples/codegen-customization/codegen/src/main/scala/demo/Config.scala
@@ -3,7 +3,7 @@ package demo
 object Config{
   val initScripts = Seq("drop-tables.sql","create-tables.sql","populate-tables.sql")
   // FIXME don't forget to adjust it according to your environment
-  val url = "jdbc:postgresql://172.17.0.1/test?user=test"
+  val url = "jdbc:postgresql://192.168.99.100:5432/test?user=test&password=test"
   val jdbcDriver =  "org.postgresql.Driver"
-  val slickProfile = MyPostgresDriver
+  val slickProfile: MyPostgresDriver = MyPostgresDriver
 }

--- a/examples/codegen-customization/codegen/src/main/scala/demo/MyPostgresDriver.scala
+++ b/examples/codegen-customization/codegen/src/main/scala/demo/MyPostgresDriver.scala
@@ -2,7 +2,7 @@ package demo
 
 import com.github.tminglei.slickpg._
 
-trait MyPostgresDriver extends ExPostgresDriver
+trait MyPostgresDriver extends ExPostgresProfile
                           with PgArraySupport
                           with PgDateSupportJoda
                           with PgEnumSupport

--- a/examples/codegen-customization/docker-compose.yml
+++ b/examples/codegen-customization/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.3'
+
+services:
+  postgres:
+    image: postgres:9.6
+    restart: always
+    environment:
+      POSTGRES_DB: 'test'
+      POSTGRES_USER: 'test'
+      POSTGRES_PASSWORD: 'test'
+    ports:
+      - "5432:5432"
+  pgweb:
+    image: sosedoff/pgweb
+    restart: always
+    environment:
+      DATABASE_URL: postgres://test:test@postgres:5432/test?sslmode=disable
+    depends_on:
+      - postgres
+    links:
+      - postgres:postgres
+    ports:
+      - "8081:8081"

--- a/examples/codegen-customization/project/build.properties
+++ b/examples/codegen-customization/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.16

--- a/examples/codegen-customization/project/plugins.sbt
+++ b/examples/codegen-customization/project/plugins.sbt
@@ -1,3 +1,0 @@
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")
-
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")

--- a/examples/codegen-customization/src/sql/create-tables.sql
+++ b/examples/codegen-customization/src/sql/create-tables.sql
@@ -1,22 +1,24 @@
 create table SUPPLIER
   (ID integer NOT NULL,
   NAME varchar(40) NOT NULL,
-  LOCATION geometry,
   STREET varchar(40) NOT NULL,
   CITY varchar(20) NOT NULL,
   STATE char(2) NOT NULL,
   ZIP char(5),
+  ASDF _text Not null,
   PRIMARY KEY (ID));
-  
+
 create table COFFEE
   (NAME varchar(32) NOT NULL,
   SUP_ID int NOT NULL,
   PRICE numeric(10,2) NOT NULL,
   SALES integer NOT NULL,
   TOTAL integer NOT NULL,
+  ETC_STR _text NOT NULL,
+  ETC_INT _int4 NOT NULL,
   PRIMARY KEY (NAME),
   FOREIGN KEY (SUP_ID) REFERENCES SUPPLIER (ID));
-  
+
 create table COFFEE_DESCRIPTION
   (NAME varchar(32) NOT NULL,
   DESCRIPTION text NOT NULL,
@@ -27,7 +29,7 @@ create table RSS_FEED
   (NAME varchar(32) NOT NULL,
   FEED_XML text NOT NULL,
   PRIMARY KEY (NAME));
-  
+
 create table COFFEE_INVENTORY
   (WAREHOUSE_ID integer NOT NULL,
   COFFEE_NAME varchar(32) NOT NULL,
@@ -36,7 +38,7 @@ create table COFFEE_INVENTORY
   DATE_VAL timestamp,
   FOREIGN KEY (COFFEE_NAME) REFERENCES COFFEE (NAME),
   FOREIGN KEY (SUP_ID) REFERENCES SUPPLIER (ID));
-  
+
 create table MERCH_INVENTORY
   (ITEM_ID integer NOT NULL,
   ITEM_NAME varchar(20),
@@ -45,16 +47,16 @@ create table MERCH_INVENTORY
   DATE_VAL timestamp,
   PRIMARY KEY (ITEM_ID),
   FOREIGN KEY (SUP_ID) REFERENCES SUPPLIER (ID));
-  
+
 create table COFFEE_HOUSE
   (ID integer NOT NULL,
   CITY varchar(32),
-  LOCATION geometry,
   COFFEE int NOT NULL,
   MERCH int NOT NULL,
   TOTAL int NOT NULL,
   PRIMARY KEY (ID));
-  
+
 create table DATA_REPOSITORY
   (DOCUMENT_NAME varchar(50),
-  URL varchar(200));
+  URL varchar(200)
+  );

--- a/examples/codegen-customization/src/sql/populate-tables.sql
+++ b/examples/codegen-customization/src/sql/populate-tables.sql
@@ -1,8 +1,8 @@
-insert into SUPPLIER values(49,  'Superior Coffee', null, '1 Party Place', 'Mendocino', 'CA', '95460');
-insert into SUPPLIER values(101, 'Acme, Inc.', null, '99 Market Street', 'Groundsville', 'CA', '95199');
-insert into SUPPLIER values(150, 'The High Ground', null, '100 Coffee Lane', 'Meadows', 'CA', '93966');
-insert into SUPPLIER values(456, 'Restaurant Supplies, Inc.', null, '200 Magnolia Street', 'Meadows', 'CA', '93966');
-insert into SUPPLIER values(927, 'Professional Kitchen', null, '300 Daisy Avenue', 'Groundsville', 'CA', '95199');
+insert into SUPPLIER values(49,  'Superior Coffee', '1 Party Place', 'Mendocino', 'CA', '95460');
+insert into SUPPLIER values(101, 'Acme, Inc.', '99 Market Street', 'Groundsville', 'CA', '95199');
+insert into SUPPLIER values(150, 'The High Ground', '100 Coffee Lane', 'Meadows', 'CA', '93966');
+insert into SUPPLIER values(456, 'Restaurant Supplies, Inc.', '200 Magnolia Street', 'Meadows', 'CA', '93966');
+insert into SUPPLIER values(927, 'Professional Kitchen', '300 Daisy Avenue', 'Groundsville', 'CA', '95199');
 
 insert into COFFEE values('Colombian',          101, 7.99, 0, 0);
 insert into COFFEE values('French_Roast',       49,  8.99, 0, 0);


### PR DESCRIPTION
Updated `codegen-customization` example.

- In latest slick-pg, codegen for collection types don't work properly. its `rawType` generates `scala.collection.Seq` for list types and `scala.collection.Map` for map types, also it doesn't reveal any generic type info. As previous example checks sqlType only if rawType is `String`, it doesn't work. I fixed that to check sqlType first for collection types and then check other types.

- added `docker-compose.yml`, you can just run `docker-compose up` and then run example. and check ui by `dockerhost:8081` on browser

- and updated dependencies