### PR TITLE
Bump scala

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: scala
 scala:
    - 2.11.12
-   - 2.12.4
+   - 2.12.7
 jdk:
   - oraclejdk8
 before_install:

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ lazy val commonSettings = Seq(
   name := "slick-pg",
   version := "0.16.3",
 
-  scalaVersion := "2.12.6",
-  crossScalaVersions := Seq("2.12.6", "2.11.12"),
+  scalaVersion := "2.12.7",
+  crossScalaVersions := Seq("2.12.7", "2.11.12"),
   scalacOptions ++= Seq("-deprecation", "-feature",
     "-language:implicitConversions",
     "-language:reflectiveCalls",

--- a/examples/codegen-customization/build.sbt
+++ b/examples/codegen-customization/build.sbt
@@ -14,7 +14,7 @@ lazy val codegen = project
 
 // shared sbt config between main project and codegen project
 lazy val sharedSettings = Seq(
-  scalaVersion := "2.12.5",
+  scalaVersion := "2.12.7",
   scalacOptions := Seq("-feature", "-unchecked", "-deprecation"),
   libraryDependencies ++= List(
     "com.typesafe.slick" %% "slick" % "3.2.3",

--- a/examples/play-slick-example/build.sbt
+++ b/examples/play-slick-example/build.sbt
@@ -7,7 +7,7 @@ PlayKeys.playOmnidoc := false
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
 
-scalaVersion := "2.12.3"
+scalaVersion := "2.12.7"
 
 description := "slick-pg play integration example project"
 


### PR DESCRIPTION
Release notes: https://github.com/scala/scala/releases/tag/v2.12.7

> Compiler performance has improved significantly again, and is mostly on par with 2.13. Concretely, you should see a 10% drop in compile times since 2.12.6, according to our compiler benchmarks.