### PR TITLE
update to slick 3.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ def mainDependencies(scalaVersion: String) = {
   }
   Seq (
     "org.scala-lang" % "scala-reflect" % scalaVersion,
-    "com.typesafe.slick" %% "slick" % "3.2.3",
+    "com.typesafe.slick" %% "slick" % "3.3.0",
     "org.postgresql" % "postgresql" % "42.2.5",
     "org.slf4j" % "slf4j-simple" % "1.7.24" % "provided",
     "org.scalatest" %% "scalatest" % "3.0.5" % "test"

--- a/core/src/main/scala/com/github/tminglei/slickpg/ExPostgresProfile.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/ExPostgresProfile.scala
@@ -229,12 +229,12 @@ trait ExPostgresProfile extends JdbcProfile with PostgresProfile with Logging { 
       } else table.primaryKeys
     }
 
-    override protected def createTable: String = {
+    override protected def createTable(checkNotExists: Boolean): String = {
       if(table.isInstanceOf[InheritingTable]) {
         val hTable = table.asInstanceOf[InheritingTable].inherited
         val hTableNode = hTable.toNode.asInstanceOf[TableExpansion].table.asInstanceOf[TableNode]
-        s"${super.createTable} inherits (${quoteTableName(hTableNode)})"
-      } else super.createTable
+        s"${super.createTable(checkNotExists)} inherits (${quoteTableName(hTableNode)})"
+      } else super.createTable(checkNotExists)
     }
   }
 }

--- a/src/main/scala/com/github/tminglei/slickpg/PgDate2Support.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgDate2Support.scala
@@ -100,7 +100,16 @@ trait PgDate2Support extends date.PgDateExtensions with utils.PgCommonJdbcTypes 
       toInfinitable[Instant](Instant.MAX, Instant.MIN, _.toString)
   }
 
-  trait Date2DateTimeImplicits[INTERVAL] extends Date2DateTimeFormatters {
+  trait Date2DateTimeImplicits[INTERVAL] extends Date2DateTimeFormatters with API {
+    //hide date types introduced in slick 3.3.0 to preserve compatibility
+    override def offsetDateTimeColumnType = columnTypes.offsetDateTimeType
+    override def zonedDateTimeColumnType = columnTypes.zonedDateType
+    override def localTimeColumnType = columnTypes.localTimeType
+    override def localDateColumnType = columnTypes.localDateType
+    override def localDateTimeColumnType = columnTypes.localDateTimeType
+    override def offsetTimeColumnType = columnTypes.offsetTimeType
+    override def instantColumnType = columnTypes.instantType
+
     implicit val date2DateTypeMapper: JdbcType[LocalDate] = new GenericDateJdbcType[LocalDate]("date", java.sql.Types.DATE)
     implicit val date2TimeTypeMapper: JdbcType[LocalTime] = new GenericDateJdbcType[LocalTime]("time", java.sql.Types.TIME)
     implicit val date2DateTimeTypeMapper: JdbcType[LocalDateTime] = new GenericDateJdbcType[LocalDateTime]("timestamp", java.sql.Types.TIMESTAMP)


### PR DESCRIPTION
this updates binary dep, adjusts for new parameter in createTable, and removes newly added support for java.time.* since it already exists and we'd like to preserve compatibility with existing formats