### PR TITLE
WIP: some changes to support scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: required
 language: scala
 scala:
    - 2.11.12
-   - 2.12.7
+   - 2.12.8
+   - 2.13.0
 jdk:
   - oraclejdk8
 before_install:

--- a/addons/jawn/src/main/scala/com/github/tminglei/slickpg/PgJawnJsonSupport.scala
+++ b/addons/jawn/src/main/scala/com/github/tminglei/slickpg/PgJawnJsonSupport.scala
@@ -5,7 +5,7 @@ import scala.reflect.classTag
 
 trait PgJawnJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes { driver: PostgresProfile =>
   import driver.api._
-  import jawn.ast._
+  import org.typelevel.jawn.ast._
 
   ///---
   def pgjson: String

--- a/addons/jawn/src/test/scala/com/github/tminglei/slickpg/PgJawnJsonSupportSuite.scala
+++ b/addons/jawn/src/test/scala/com/github/tminglei/slickpg/PgJawnJsonSupportSuite.scala
@@ -2,8 +2,8 @@ package com.github.tminglei.slickpg
 
 import java.util.concurrent.Executors
 
-import jawn._
-import jawn.ast._
+import org.typelevel.jawn._
+import org.typelevel.jawn.ast._
 
 import org.scalatest.FunSuite
 import slick.jdbc.{GetResult, PostgresProfile}

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val commonSettings = Seq(
   version := "0.17.3",
 
   scalaVersion := "2.12.8",
-  crossScalaVersions := Seq("2.12.8", "2.11.12"),
+  crossScalaVersions := Seq("2.12.8", "2.11.12", "2.13.0"),
   scalacOptions ++= Seq("-deprecation", "-feature",
     "-language:implicitConversions",
     "-language:reflectiveCalls",
@@ -65,10 +65,10 @@ def mainDependencies(scalaVersion: String) = {
   }
   Seq (
     "org.scala-lang" % "scala-reflect" % scalaVersion,
-    "com.typesafe.slick" %% "slick" % "3.3.0",
+    "com.typesafe.slick" %% "slick" % "3.3.2",
     "org.postgresql" % "postgresql" % "42.2.5",
     "org.slf4j" % "slf4j-simple" % "1.7.24" % "provided",
-    "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.8" % "test"
   ) ++ extractedLibs
 }
 
@@ -105,9 +105,9 @@ lazy val slickPgJson4s = Project(id = "slick-pg_json4s", base = file("./addons/j
     name := "slick-pg_json4s",
     description := "Slick extensions for PostgreSQL - json4s module",
     libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
-      "org.json4s" %% "json4s-ast" % "3.6.3",
-      "org.json4s" %% "json4s-core" % "3.6.3",
-      "org.json4s" %% "json4s-native" % "3.6.3" % "test"
+      "org.json4s" %% "json4s-ast" % "3.6.6",
+      "org.json4s" %% "json4s-core" % "3.6.6",
+      "org.json4s" %% "json4s-native" % "3.6.6" % "test"
     )
   )
 ) dependsOn (slickPgCore)
@@ -137,7 +137,7 @@ lazy val slickPgPlayJson = Project(id = "slick-pg_play-json", base = file("./add
     name := "slick-pg_play-json",
     description := "Slick extensions for PostgreSQL - play-json module",
     libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
-      "com.typesafe.play" %% "play-json" % "2.7.3"
+      "com.typesafe.play" %% "play-json" % "2.7.4"
     )
   )
 ) dependsOn (slickPgCore)
@@ -157,9 +157,9 @@ lazy val slickPgCirceJson = Project(id = "slick-pg_circe-json", base = file("./a
     name := "slick-pg_circe-json",
     description := "Slick extensions for PostgreSQL - circe module",
     libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
-      "io.circe" %% "circe-core" % "0.11.0",
-      "io.circe" %% "circe-generic" % "0.11.0",
-      "io.circe" %% "circe-parser" % "0.11.0"
+      "io.circe" %% "circe-core" % "0.12.0-M3",
+      "io.circe" %% "circe-generic" % "0.12.0-M3",
+      "io.circe" %% "circe-parser" % "0.12.0-M3"
     )
   )
 ) dependsOn (slickPgCore)
@@ -169,7 +169,7 @@ lazy val slickPgArgonaut = Project(id = "slick-pg_argonaut", base = file("./addo
     name := "slick-pg_argonaut",
     description := "Slick extensions for PostgreSQL - argonaut module",
     libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
-      "io.argonaut" %% "argonaut" % "6.2.2"
+      "io.argonaut" %% "argonaut" % "6.2.3"
     )
   )
 ) dependsOn (slickPgCore)

--- a/build.sbt
+++ b/build.sbt
@@ -179,7 +179,7 @@ lazy val slickPgJawn = Project(id = "slick-pg_jawn", base = file("./addons/jawn"
     name := "slick-pg_jawn",
     description := "Slick extensions for PostgreSQL - jawn module",
     libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
-      "org.spire-math" %% "jawn-ast" % "0.13.0"
+      "org.typelevel" %% "jawn-ast" % "0.14.2"
     )
   )
 ) dependsOn (slickPgCore)

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ lazy val commonSettings = Seq(
 
   resolvers += Resolver.mavenLocal,
   resolvers += Resolver.sonatypeRepo("snapshots"),
-  resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
-  resolvers += "spray" at "http://repo.spray.io/",
+  resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/",
+
   //    publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))),
   publishTo := {
     val nexus = "https://oss.sonatype.org/"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 logLevel := Level.Warn
 
 // The Typesafe repository 
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Add sbt PGP Plugin
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")

--- a/src/main/scala/com/github/tminglei/slickpg/PgHStoreSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgHStoreSupport.scala
@@ -1,6 +1,6 @@
 package com.github.tminglei.slickpg
 
-import scala.collection.convert.{WrapAsJava, WrapAsScala}
+import scala.collection.JavaConverters._
 import org.postgresql.util.HStoreConverter
 import slick.jdbc.{JdbcType, PositionedResult, PostgresProfile}
 import scala.reflect.classTag
@@ -22,8 +22,8 @@ trait PgHStoreSupport extends hstore.PgHStoreExtensions with utils.PgCommonJdbcT
     implicit val simpleHStoreTypeMapper: JdbcType[Map[String, String]] =
       new GenericJdbcType[Map[String, String]](
         "hstore",
-        (v) => WrapAsScala.mapAsScalaMap(HStoreConverter.fromString(v)).toMap,
-        (v) => HStoreConverter.toString(WrapAsJava.mapAsJavaMap(v)),
+        (v) => mapAsScalaMap(HStoreConverter.fromString(v)).toMap,
+        (v) => HStoreConverter.toString(mapAsJavaMap(v)),
         hasLiteralForm = false
       )
 
@@ -42,7 +42,7 @@ trait PgHStoreSupport extends hstore.PgHStoreExtensions with utils.PgCommonJdbcT
     implicit class PgHStorePositionedResult(r: PositionedResult) {
       def nextHStore() = nextHStoreOption().getOrElse(Map.empty)
       def nextHStoreOption() = r.nextStringOption().map { v =>
-        WrapAsScala.mapAsScalaMap(HStoreConverter.fromString(v).asInstanceOf[java.util.Map[String, String]]).toMap
+        mapAsScalaMap(HStoreConverter.fromString(v).asInstanceOf[java.util.Map[String, String]]).toMap
       }
     }
 
@@ -50,8 +50,8 @@ trait PgHStoreSupport extends hstore.PgHStoreExtensions with utils.PgCommonJdbcT
     implicit val getHStore = mkGetResult(_.nextHStore())
     implicit val getHStoreOption = mkGetResult(_.nextHStoreOption())
     implicit val setHStore = mkSetParameter[Map[String, String]]("hstore",
-      (v) => HStoreConverter.toString(WrapAsJava.mapAsJavaMap(v)))
+      (v) => HStoreConverter.toString(mapAsJavaMap(v)))
     implicit val setHStoreOption = mkOptionSetParameter[Map[String, String]]("hstore",
-      (v) => HStoreConverter.toString(WrapAsJava.mapAsJavaMap(v)))
+      (v) => HStoreConverter.toString(mapAsJavaMap(v)))
   }
 }

--- a/src/main/scala/com/github/tminglei/slickpg/PgHStoreSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgHStoreSupport.scala
@@ -22,8 +22,8 @@ trait PgHStoreSupport extends hstore.PgHStoreExtensions with utils.PgCommonJdbcT
     implicit val simpleHStoreTypeMapper: JdbcType[Map[String, String]] =
       new GenericJdbcType[Map[String, String]](
         "hstore",
-        (v) => mapAsScalaMap(HStoreConverter.fromString(v)).toMap,
-        (v) => HStoreConverter.toString(mapAsJavaMap(v)),
+        (v) => HStoreConverter.fromString(v).asScala.toMap,
+        (v) => HStoreConverter.toString(v.asJava),
         hasLiteralForm = false
       )
 
@@ -42,7 +42,7 @@ trait PgHStoreSupport extends hstore.PgHStoreExtensions with utils.PgCommonJdbcT
     implicit class PgHStorePositionedResult(r: PositionedResult) {
       def nextHStore() = nextHStoreOption().getOrElse(Map.empty)
       def nextHStoreOption() = r.nextStringOption().map { v =>
-        mapAsScalaMap(HStoreConverter.fromString(v).asInstanceOf[java.util.Map[String, String]]).toMap
+        HStoreConverter.fromString(v).asInstanceOf[java.util.Map[String, String]].asScala.toMap
       }
     }
 
@@ -50,8 +50,8 @@ trait PgHStoreSupport extends hstore.PgHStoreExtensions with utils.PgCommonJdbcT
     implicit val getHStore = mkGetResult(_.nextHStore())
     implicit val getHStoreOption = mkGetResult(_.nextHStoreOption())
     implicit val setHStore = mkSetParameter[Map[String, String]]("hstore",
-      (v) => HStoreConverter.toString(mapAsJavaMap(v)))
+      (v) => HStoreConverter.toString(v.asJava))
     implicit val setHStoreOption = mkOptionSetParameter[Map[String, String]]("hstore",
-      (v) => HStoreConverter.toString(mapAsJavaMap(v)))
+      (v) => HStoreConverter.toString(v.asJava))
   }
 }


### PR DESCRIPTION
* upgrade some dependencies
* update some Java conversions due to Scala 2.13 removing deprecated WrapAsJava, WrapAsScala
* uses circe 0.12.0-M3 while full release is awaited
* jawn-parser - use latest typelevel version (taken over from spire-math)