### PR TITLE
Upgrade postgresql JDBC driver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,7 @@ def mainDependencies(scalaVersion: String) = {
   Seq (
     "org.scala-lang" % "scala-reflect" % scalaVersion,
     "com.typesafe.slick" %% "slick" % "3.3.2",
-    "org.postgresql" % "postgresql" % "42.2.5",
+    "org.postgresql" % "postgresql" % "42.2.14",
     "org.slf4j" % "slf4j-simple" % "1.7.24" % "provided",
     "org.scalatest" %% "scalatest" % "3.0.8" % "test"
   ) ++ extractedLibs


### PR DESCRIPTION
Current version contains [a serious security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2020-13692) fixed in the latest version

Upgrading protects users who import the vulnerable version transitively