### PR TITLE
Fix escaping quotes in string arrays

### DIFF
--- a/core/src/main/scala/com/github/tminglei/slickpg/utils/PlainSQLUtils.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/utils/PlainSQLUtils.scala
@@ -62,7 +62,7 @@ object PlainSQLUtils extends Logging {
 
   private def internalSetArray[T: ClassTag](baseType: String, v: Option[Seq[T]], p: PositionedParameters,
           toStr: (T => String), seqToStr: Option[(Seq[T] => String)]) = {
-    val _seqToStr = seqToStr.getOrElse(mkString(toStr) _); p.pos += 1
+    val _seqToStr = seqToStr.getOrElse(mkStringUnsafe(toStr) _); p.pos += 1
     v match {
       case Some(vList) => p.ps.setArray(p.pos, mkArray(_seqToStr)(baseType, vList))
       case None        => p.ps.setNull(p.pos, java.sql.Types.ARRAY)

--- a/src/test/scala/com/github/tminglei/slickpg/PgArraySupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgArraySupportSuite.scala
@@ -217,7 +217,7 @@ class PgArraySupportSuite extends FunSuite {
       )
     }
 
-    val b = ArrayBean1(101L, "tt".getBytes, List(UUID.randomUUID()), Some(List("tewe", "ttt")), List(111L), List(1, 2), Vector(3, 5), List(1.2f, 43.32f), List(21.35d), List(true, true),
+    val b = ArrayBean1(101L, "tt".getBytes, List(UUID.randomUUID()), Some(List("tewe", "ttt", "apostrophe'")), List(111L), List(1, 2), Vector(3, 5), List(1.2f, 43.32f), List(21.35d), List(true, true),
       List(new Date(System.currentTimeMillis())), List(new Time(System.currentTimeMillis())), List(new Timestamp(System.currentTimeMillis())), List(Institution(579)))
 
     Await.result(db.run(


### PR DESCRIPTION
# Fix escaping quotes in string arrays

Thanks for this library!

This PR fixes an issue with redundant escaping of quotes (`''`) in plain SQL support for `SetParameter`. Quotes in plain arrays are escaped twice. Once by `escaped` method and the second time by (I presume) `java.sql.PreparedStatement` causing a redundant quote being inserted.

The issue shows when extending tests. For `Some(List("tewe", "ttt", "apostrophe'")`:

```
[info] - Array Plain SQL support *** FAILED ***
[info]   "apostrophe'[]" did not equal "apostrophe'[']" (PgArraySupportSuite.scala:247)
```

It is fixed by leaving escaping up to `PreparedStatement` when serialized as a parameter (`SetParameter`) and escaping explicitly when inlined as per https://github.com/tminglei/slick-pg/issues/473. 