### PR TITLE
Remove all \u0000 characters from JSON strings in simple json support

### DIFF
--- a/src/main/scala/com/github/tminglei/slickpg/PgJsonSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgJsonSupport.scala
@@ -1,5 +1,6 @@
 package com.github.tminglei.slickpg
 
+import com.github.tminglei.slickpg.utils.JsonUtils
 import slick.jdbc.{JdbcType, PositionedResult, PostgresProfile}
 import scala.reflect.classTag
 
@@ -32,7 +33,7 @@ trait PgJsonSupport extends json.PgJsonExtensions with utils.PgCommonJdbcTypes {
       new GenericJdbcType[JsonString](
         pgjson,
         (v) => JsonString(v),
-        (v) => v.value,
+        (v) => JsonUtils.clean(v.value),
         hasLiteralForm = false
       )
 


### PR DESCRIPTION
In #348 and #475, serde-specific artifacts (circe, play-json, etc.) were updated to strip `\u0000` characters (which are disallowed for json/jsonb values in Postgres) - this PR updates the default `PgJsonSupport` to also perform the same stripping logic. 