### PR TITLE
use testcontainers for tests, update addon/scala versions, 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,11 @@
 dist: trusty
 sudo: required
+services:
+  - docker
 language: scala
 scala:
    - 2.11.12
-   - 2.12.12
-   - 2.13.3
+   - 2.12.13
+   - 2.13.5
 jdk:
   - oraclejdk8
-before_install:
-  - sudo /etc/init.d/postgresql stop
-  - sudo apt-get -y remove --purge postgresql-9.1
-  - sudo apt-get -y remove --purge postgresql-9.2
-  - sudo apt-get -y remove --purge postgresql-9.3
-  - sudo apt-get -y remove --purge postgresql-9.4
-  - sudo apt-get -y remove --purge postgresql-9.5
-  - sudo apt-get -y remove --purge postgresql-9.6
-  - sudo apt-get -y autoremove
-  - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main 10" >> /etc/apt/sources.list.d/postgresql.list'
-  - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  - sudo apt-get update
-  - sudo apt-get -y install postgresql-10 postgresql-contrib-10 postgresql-10-postgis-2.4
-  - sudo sh -c 'echo "local all postgres trust" > /etc/postgresql/10/main/pg_hba.conf'
-  - sudo sh -c 'echo -n "host all all 127.0.0.1/32 trust" >> /etc/postgresql/10/main/pg_hba.conf'
-  - sudo service postgresql restart 10
-before_script:
-  - psql -c 'create database test;' -U postgres
-  - psql test -c 'CREATE EXTENSION IF NOT EXISTS hstore;' -U postgres
-  - psql test -c 'CREATE EXTENSION IF NOT EXISTS ltree;' -U postgres
-  - psql test -c 'CREATE EXTENSION IF NOT EXISTS postgis;' -U postgres
-  - psql test -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;' -U postgres

--- a/addons/argonaut/src/test/scala/com/github/tminglei/slickpg/PgArgonautSupportSuite.scala
+++ b/addons/argonaut/src/test/scala/com/github/tminglei/slickpg/PgArgonautSupportSuite.scala
@@ -4,13 +4,13 @@ import java.util.concurrent.Executors
 
 import argonaut.Argonaut._
 import argonaut._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.{GetResult, PostgresProfile}
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
-class PgArgonautSupportSuite extends FunSuite {
+class PgArgonautSupportSuite extends AnyFunSuite with PostgresContainer {
   implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 
   trait MyPostgresProfile extends PostgresProfile
@@ -32,7 +32,7 @@ class PgArgonautSupportSuite extends FunSuite {
   ///
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class JsonBean(id: Long, json: Json)
 

--- a/addons/circe-json/src/test/scala/com/github/tminglei/slickpg/PgCirceJsonSupportSuite.scala
+++ b/addons/circe-json/src/test/scala/com/github/tminglei/slickpg/PgCirceJsonSupportSuite.scala
@@ -5,13 +5,13 @@ import java.util.concurrent.Executors
 import cats.syntax.either._
 import io.circe._
 import io.circe.parser._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.{GetResult, PostgresProfile}
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
-class PgCirceJsonSupportSuite extends FunSuite {
+class PgCirceJsonSupportSuite extends AnyFunSuite with PostgresContainer {
   implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 
   trait MyPostgresProfile extends PostgresProfile
@@ -32,7 +32,7 @@ class PgCirceJsonSupportSuite extends FunSuite {
 
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class JsonBean(id: Long, json: Json)
 

--- a/addons/jawn/src/test/scala/com/github/tminglei/slickpg/PgJawnJsonSupportSuite.scala
+++ b/addons/jawn/src/test/scala/com/github/tminglei/slickpg/PgJawnJsonSupportSuite.scala
@@ -5,13 +5,13 @@ import java.util.concurrent.Executors
 import org.typelevel.jawn._
 import org.typelevel.jawn.ast._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.{GetResult, PostgresProfile}
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
-class PgJawnJsonSupportSuite extends FunSuite {
+class PgJawnJsonSupportSuite extends AnyFunSuite with PostgresContainer {
   implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 
   trait MyPostgresProfile extends PostgresProfile
@@ -38,7 +38,7 @@ class PgJawnJsonSupportSuite extends FunSuite {
   ///
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class JsonBean(id: Long, json: JValue, jsons: List[JValue])
 

--- a/addons/joda-time/src/test/scala/com/github/tminglei/slickpg/PgDateSupportJodaSuite.scala
+++ b/addons/joda-time/src/test/scala/com/github/tminglei/slickpg/PgDateSupportJodaSuite.scala
@@ -3,12 +3,12 @@ package com.github.tminglei.slickpg
 import java.util.concurrent.Executors
 
 import org.joda.time._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.{GetResult, PostgresProfile}
 
 import scala.concurrent.{Await, ExecutionContext}
 
-class PgDateSupportJodaSuite extends FunSuite {
+class PgDateSupportJodaSuite extends AnyFunSuite with PostgresContainer {
   implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 
   trait MyPostgresProfile extends PostgresProfile
@@ -26,7 +26,7 @@ class PgDateSupportJodaSuite extends FunSuite {
   ///
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class DatetimeBean(
     id: Long,

--- a/addons/json4s/src/test/scala/com/github/tminglei/slickpg/PgJson4sSupportSuite.scala
+++ b/addons/json4s/src/test/scala/com/github/tminglei/slickpg/PgJson4sSupportSuite.scala
@@ -3,13 +3,13 @@ package com.github.tminglei.slickpg
 import java.util.concurrent.Executors
 
 import org.json4s._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.{GetResult, PostgresProfile}
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
-class PgJson4sSupportSuite extends FunSuite {
+class PgJson4sSupportSuite extends AnyFunSuite with PostgresContainer {
   implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 
   trait MyPostgresProfile extends PostgresProfile
@@ -40,7 +40,7 @@ class PgJson4sSupportSuite extends FunSuite {
   import MyPostgresProfile.api._
   import MyPostgresProfile.jsonMethods._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class JsonBean(id: Long, json: JValue, jsons: List[JValue])
 

--- a/addons/jts/src/test/scala/com/github/tminglei/slickpg/PgPostGISSupportSuite.scala
+++ b/addons/jts/src/test/scala/com/github/tminglei/slickpg/PgPostGISSupportSuite.scala
@@ -4,13 +4,13 @@ import java.util.concurrent.Executors
 
 import com.vividsolutions.jts.geom.{Geometry, Point}
 import com.vividsolutions.jts.io.{WKBWriter, WKTReader, WKTWriter}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.{GetResult, PostgresProfile}
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
-class PgPostGISSupportSuite extends FunSuite {
+class PgPostGISSupportSuite extends AnyFunSuite with PostgresContainer {
   implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 
   trait MyPostgresProfile extends ExPostgresProfile with PgPostGISSupport {
@@ -27,7 +27,10 @@ class PgPostGISSupportSuite extends FunSuite {
   import MyPostgresProfile.api._
   import PgGeographyTypes._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  override lazy val imageName: String = "postgis/postgis"
+  override lazy val imageTag: String = "11-3.0"
+  
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class GeometryBean(id: Long, geom: Geometry, geog: Geography)
 
@@ -811,9 +814,9 @@ class PgPostGISSupportSuite extends FunSuite {
           // ClusterKMeans
           PointTests.map(r => (r.id, r.point.clusterKMeans(2) :: Over)).result.map {
             r =>
-              assert(r.find(_._1 == pbean1.id).get._2 == 0)
-              assert(r.find(_._1 == pbean2.id).get._2 == 1)
-              assert(r.find(_._1 == pbean3.id).get._2 == 1)
+              assert(r.find(_._1 == pbean1.id).get._2 == 1)
+              assert(r.find(_._1 == pbean2.id).get._2 == 0)
+              assert(r.find(_._1 == pbean3.id).get._2 == 0)
           }
         )
       ).andFinally(

--- a/addons/play-json/src/test/scala/com/github/tminglei/slickpg/PgPlayJsonSupportSuite.scala
+++ b/addons/play-json/src/test/scala/com/github/tminglei/slickpg/PgPlayJsonSupportSuite.scala
@@ -3,14 +3,14 @@ package com.github.tminglei.slickpg
 import java.util.concurrent.Executors
 
 import utils.JsonUtils
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import play.api.libs.json._
 import slick.jdbc.{GetResult, PostgresProfile}
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
-class PgPlayJsonSupportSuite extends FunSuite {
+class PgPlayJsonSupportSuite extends AnyFunSuite with PostgresContainer {
   implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 
   case class JBean(name: String, count: Int)
@@ -49,7 +49,7 @@ class PgPlayJsonSupportSuite extends FunSuite {
   ///
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class JsonBean(id: Long, json: JsValue, jsons: List[JsValue], jbean: JBean, jbeans: List[JBean])
 

--- a/addons/spray-json/src/test/scala/com/github/tminglei/slickpg/PgSprayJsonSupportSuite.scala
+++ b/addons/spray-json/src/test/scala/com/github/tminglei/slickpg/PgSprayJsonSupportSuite.scala
@@ -2,14 +2,14 @@ package com.github.tminglei.slickpg
 
 import java.util.concurrent.Executors
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.{GetResult, PostgresProfile}
 import spray.json._
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
-class PgSprayJsonSupportSuite extends FunSuite {
+class PgSprayJsonSupportSuite extends AnyFunSuite with PostgresContainer {
   implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 
   case class JBean(name: String, count: Int)
@@ -38,7 +38,7 @@ class PgSprayJsonSupportSuite extends FunSuite {
   ///
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class JsonBean(id: Long, json: JsValue, jbean: JBean)
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,15 @@
+val scala213 = "2.13.5"
+val scala212 = "2.12.13"
+val scala211 = "2.11.12"
+
 lazy val commonSettings = Seq(
   organizationName := "slick-pg",
   organization := "com.github.tminglei",
   name := "slick-pg",
   version := "0.19.5",
 
-  scalaVersion := "2.13.3",
-  crossScalaVersions := Seq("2.13.3", "2.12.12", "2.11.12"),
+  scalaVersion := scala213,
+  crossScalaVersions := Seq(scala213, scala212, scala211),
   scalacOptions ++= Seq("-deprecation", "-feature",
     "-language:implicitConversions",
     "-language:reflectiveCalls",
@@ -68,9 +72,11 @@ def mainDependencies(scalaVersion: String) = {
   Seq (
     "org.scala-lang" % "scala-reflect" % scalaVersion,
     "com.typesafe.slick" %% "slick" % "3.3.3",
-    "org.postgresql" % "postgresql" % "42.2.14",
-    "org.slf4j" % "slf4j-simple" % "1.7.24" % "provided",
-    "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+    "org.postgresql" % "postgresql" % "42.2.19",
+    "org.slf4j" % "slf4j-simple" % "1.7.30" % "provided",
+    "org.scalatest" %% "scalatest" % "3.2.7" % "test",
+    "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.39.3" % "test",
+    "com.dimafeng" %% "testcontainers-scala-postgresql" % "0.39.3" % "test"
   ) ++ extractedLibs
 }
 
@@ -89,7 +95,7 @@ lazy val slickPg = (project in file("."))
     description := "Slick extensions for PostgreSQL",
     libraryDependencies := mainDependencies(scalaVersion.value)
   )
-  .dependsOn (slickPgCore)
+  .dependsOn (slickPgCore % "test->test;compile->compile")
   .aggregate (slickPgCore, slickPgJoda, slickPgJson4s, slickPgJts, slickPgJtsLt, slickPgPlayJson, slickPgSprayJson, slickPgCirceJson, slickPgArgonaut, slickPgJawn)
 
 lazy val slickPgJoda = (project in file("./addons/joda-time"))
@@ -98,10 +104,10 @@ lazy val slickPgJoda = (project in file("./addons/joda-time"))
     name := "slick-pg_joda-time",
     description := "Slick extensions for PostgreSQL - joda time module",
     libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
-      "joda-time" % "joda-time" % "2.10.5"
+      "joda-time" % "joda-time" % "2.10.10"
     )
   )
-  .dependsOn (slickPgCore)
+  .dependsOn (slickPgCore % "test->test;compile->compile")
 
 lazy val slickPgJson4s = (project in file("./addons/json4s"))
   .settings(commonSettings)
@@ -109,12 +115,12 @@ lazy val slickPgJson4s = (project in file("./addons/json4s"))
     name := "slick-pg_json4s",
     description := "Slick extensions for PostgreSQL - json4s module",
     libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
-      "org.json4s" %% "json4s-ast" % "3.6.6",
-      "org.json4s" %% "json4s-core" % "3.6.6",
-      "org.json4s" %% "json4s-native" % "3.6.6" % "test"
+      "org.json4s" %% "json4s-ast" % "3.6.11",
+      "org.json4s" %% "json4s-core" % "3.6.11",
+      "org.json4s" %% "json4s-native" % "3.6.11" % "test"
     )
   )
-  .dependsOn (slickPgCore)
+  .dependsOn (slickPgCore % "test->test;compile->compile")
 
 lazy val slickPgJts = (project in file("./addons/jts"))
   .settings(commonSettings)
@@ -125,7 +131,7 @@ lazy val slickPgJts = (project in file("./addons/jts"))
       "com.vividsolutions" % "jts-core" % "1.14.0"
     )
   )
-  .dependsOn (slickPgCore)
+  .dependsOn (slickPgCore % "test->test;compile->compile")
 
 lazy val slickPgJtsLt = (project in file("./addons/jts_lt"))
   .settings(commonSettings)
@@ -133,21 +139,26 @@ lazy val slickPgJtsLt = (project in file("./addons/jts_lt"))
     name := "slick-pg_jts_lt",
     description := "Slick extensions for PostgreSQL - (locationtech) jts module",
     libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
-      "org.locationtech.jts" % "jts-core" % "1.16.1"
+      "org.locationtech.jts" % "jts-core" % "1.18.1"
     )
   )
-  .dependsOn (slickPgCore)
+  .dependsOn (slickPgCore % "test->test;compile->compile")
 
 lazy val slickPgPlayJson = (project in file("./addons/play-json"))
   .settings(commonSettings)
   .settings(
     name := "slick-pg_play-json",
     description := "Slick extensions for PostgreSQL - play-json module",
-    libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
-      "com.typesafe.play" %% "play-json" % "2.7.4"
+    libraryDependencies := mainDependencies(scalaVersion.value) ++ (
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, scalaMajor)) if scalaMajor > 11 =>
+          Seq("com.typesafe.play" %% "play-json" % "2.9.2")
+        case _ =>
+          Seq("com.typesafe.play" %% "play-json" % "2.7.4")
+      }
     )
   )
-  .dependsOn (slickPgCore)
+  .dependsOn (slickPgCore % "test->test;compile->compile")
 
 lazy val slickPgSprayJson = (project in file("./addons/spray-json"))
   .settings(commonSettings)
@@ -155,10 +166,10 @@ lazy val slickPgSprayJson = (project in file("./addons/spray-json"))
     name := "slick-pg_spray-json",
     description := "Slick extensions for PostgreSQL - spray-json module",
     libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
-      "io.spray" %%  "spray-json" % "1.3.5"
+      "io.spray" %%  "spray-json" % "1.3.6"
     )
   )
-  .dependsOn (slickPgCore)
+  .dependsOn (slickPgCore % "test->test;compile->compile")
 
 lazy val slickPgCirceJson = (project in file("./addons/circe-json"))
   .settings(commonSettings)
@@ -169,9 +180,9 @@ lazy val slickPgCirceJson = (project in file("./addons/circe-json"))
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, scalaMajor)) if scalaMajor > 11 =>
           Seq(
-            "io.circe" %% "circe-core" % "0.12.3",
-            "io.circe" %% "circe-generic" % "0.12.3",
-            "io.circe" %% "circe-parser" % "0.12.3"
+            "io.circe" %% "circe-core" % "0.13.0",
+            "io.circe" %% "circe-generic" % "0.13.0",
+            "io.circe" %% "circe-parser" % "0.13.0"
           )
         case _ =>
           Seq(
@@ -182,29 +193,39 @@ lazy val slickPgCirceJson = (project in file("./addons/circe-json"))
       }
     )
   )
-  .dependsOn (slickPgCore)
+  .dependsOn (slickPgCore % "test->test;compile->compile")
 
 lazy val slickPgArgonaut = (project in file("./addons/argonaut"))
   .settings(commonSettings)
   .settings(
     name := "slick-pg_argonaut",
     description := "Slick extensions for PostgreSQL - argonaut module",
-    libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
-      "io.argonaut" %% "argonaut" % "6.2.3"
+    libraryDependencies := mainDependencies(scalaVersion.value) ++ (
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, scalaMajor)) if scalaMajor > 11 => 
+          Seq("io.argonaut" %% "argonaut" % "6.3.3")
+        case _ =>
+          Seq("io.argonaut" %% "argonaut" % "6.2.5")
+      }
     )
   )
-  .dependsOn (slickPgCore)
+  .dependsOn (slickPgCore % "test->test;compile->compile")
 
 lazy val slickPgJawn = (project in file("./addons/jawn"))
   .settings(commonSettings)
   .settings(
     name := "slick-pg_jawn",
     description := "Slick extensions for PostgreSQL - jawn module",
-    libraryDependencies := mainDependencies(scalaVersion.value) ++ Seq(
-      "org.typelevel" %% "jawn-ast" % "0.14.2"
+    libraryDependencies := mainDependencies(scalaVersion.value) ++ (
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, scalaMajor)) if scalaMajor > 11 =>
+          Seq("org.typelevel" %% "jawn-ast" % "1.1.1")
+        case _ =>
+          Seq("org.typelevel" %% "jawn-ast" % "0.14.3")
+      }
     )
   )
-  .dependsOn (slickPgCore)
+  .dependsOn (slickPgCore % "test->test;compile->compile")
 
 
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgAggFuncCoreSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgAggFuncCoreSuite.scala
@@ -1,6 +1,6 @@
 package com.github.tminglei.slickpg
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.ast.Library.SqlFunction
 import slick.ast.{LiteralNode, ScalaBaseType}
 import slick.jdbc.JdbcType
@@ -9,10 +9,10 @@ import slick.lifted.OptionMapperDSL
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class PgAggFuncCoreSuite extends FunSuite {
+class PgAggFuncCoreSuite extends AnyFunSuite with PostgresContainer {
   import ExPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class Tab(name: String, count: Int, x: Double, y: Double)
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgAggFuncSupportSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgAggFuncSupportSuite.scala
@@ -1,11 +1,11 @@
 package com.github.tminglei.slickpg
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class PgAggFuncSupportSuite extends FunSuite {
+class PgAggFuncSupportSuite extends AnyFunSuite with PostgresContainer {
   import ExPostgresProfile.api._
 
   val PgArrayJdbcTypes = new array.PgArrayJdbcTypes with ExPostgresProfile {}
@@ -13,7 +13,7 @@ class PgAggFuncSupportSuite extends FunSuite {
   implicit val simpleStrListTypeMapper = new PgArrayJdbcTypes.SimpleArrayJdbcType[String]("text").to(_.toList)
   implicit val simpleDoubleListTypeMapper = new PgArrayJdbcTypes.SimpleArrayJdbcType[Double]("float8").to(_.toList)
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class Tab(name: String, count: Int, bool: Boolean, x: Double, y: Double)
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgInheritsSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgInheritsSuite.scala
@@ -1,14 +1,14 @@
 package com.github.tminglei.slickpg
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class PgInheritsSuite extends FunSuite {
+class PgInheritsSuite extends AnyFunSuite with PostgresContainer {
   import ExPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   abstract class BaseT[T](tag: Tag, tname: String = "test_tab1") extends Table[T](tag, tname) {
     def col1 = column[String]("COL1")

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgUpsertSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgUpsertSuite.scala
@@ -1,13 +1,13 @@
 package com.github.tminglei.slickpg
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.basic.Capability
 import slick.jdbc.JdbcCapabilities
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class PgUpsertSuite extends FunSuite {
+class PgUpsertSuite extends AnyFunSuite with PostgresContainer {
 
   object MyPostgresProfile extends ExPostgresProfile {
     // Add back `capabilities.insertOrUpdate` to enable native `upsert` support
@@ -19,7 +19,7 @@ class PgUpsertSuite extends FunSuite {
 
   import ExPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class Bean(id: Long, col1: String, col2: Int)
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgWindowFuncCoreSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgWindowFuncCoreSuite.scala
@@ -1,6 +1,6 @@
 package com.github.tminglei.slickpg
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.ast.Library.SqlFunction
 import slick.ast.LiteralNode
 import slick.jdbc.JdbcType
@@ -12,10 +12,10 @@ import scala.concurrent.duration.Duration
 /**
   * Created by tminglei on 5/5/16.
   */
-class PgWindowFuncCoreSuite extends FunSuite {
+class PgWindowFuncCoreSuite extends AnyFunSuite with PostgresContainer {
   import ExPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class Tab(col1: String, col2: String, col3: String, col4: Int)
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgWindowFuncSupportSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgWindowFuncSupportSuite.scala
@@ -2,16 +2,16 @@ package com.github.tminglei.slickpg
 
 import java.util.UUID
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class PgWindowFuncSupportSuite extends FunSuite {
+class PgWindowFuncSupportSuite extends AnyFunSuite with PostgresContainer {
   import ExPostgresProfile.api._
   import window.PgWindowFuncSupport.WindowFunctions._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class Tab(col1: Option[UUID], col2: Option[String], col3: String, col4: Int)
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/PostgresContainer.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PostgresContainer.scala
@@ -1,0 +1,52 @@
+package com.github.tminglei.slickpg
+
+import com.dimafeng.testcontainers.ForAllTestContainer
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import org.scalatest.Suite
+import org.testcontainers.utility.DockerImageName
+
+trait PostgresContainer extends ForAllTestContainer { self: Suite =>
+  
+  lazy val imageName: String = "postgres"
+  lazy val imageTag: String = "11"
+  
+  override val container: PostgreSQLContainer = PostgreSQLContainer(
+    dockerImageNameOverride = DockerImageName.parse(s"$imageName:$imageTag").asCompatibleSubstituteFor("postgres"),
+    databaseName = "test",
+    username = "postgres",
+    password = "",
+    mountPostgresDataToTmpfs = true
+  ).configure { ctx =>
+    // allow passwordless access for tests
+    ctx.withEnv("POSTGRES_HOST_AUTH_METHOD", "trust")
+    ctx.withUrlParam("user", "postgres")
+  }
+  
+  def createExtension(name: String): Unit = {
+    val createExtensionResult = container.execInContainer(
+      "sh", "-c", s"psql test -c 'CREATE EXTENSION IF NOT EXISTS $name;' -U postgres;"
+    )
+    if(createExtensionResult.getExitCode != 0){
+      println(createExtensionResult.toString)
+    }
+  }
+  
+  def createHstore(): Unit = createExtension("hstore")
+  
+  def createLtree(): Unit = createExtension("ltree")
+  
+  def createTrgm(): Unit = createExtension("pg_trgm")
+  
+  def createPostgis(): Unit = createExtension("postgis")
+  
+  override def afterStart(): Unit = {
+    createHstore()
+    createLtree()
+    createTrgm()
+    
+    // only create the postgis extension when using the postgis container
+    if(imageName == "postgis/postgis") createPostgis()
+    
+    super.afterStart()
+  }
+}

--- a/core/src/test/scala/com/github/tminglei/slickpg/lobj/LargeObjectSupportSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/lobj/LargeObjectSupportSuite.scala
@@ -3,18 +3,18 @@ package lobj
 
 import java.io.ByteArrayInputStream
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.concurrent.Await
 import scala.util.{Failure, Success}
 import scala.concurrent.duration._
 
-class LargeObjectSupportSuite extends FunSuite {
+class LargeObjectSupportSuite extends AnyFunSuite with PostgresContainer {
   import ExPostgresProfile.api._
 
   val driver = new LargeObjectSupport with ExPostgresProfile {}
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   test("upload and download large object") {
     val testString = "some string to store as a large object"

--- a/core/src/test/scala/com/github/tminglei/slickpg/str/PgStringSupportSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/str/PgStringSupportSuite.scala
@@ -4,7 +4,7 @@ package str
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -12,7 +12,7 @@ import scala.concurrent.duration.Duration
 /**
   * Created by minglei on 12/12/16.
   */
-class PgStringSupportSuite extends FunSuite {
+class PgStringSupportSuite extends AnyFunSuite with PostgresContainer {
 
   trait MyPostgresProfile1 extends ExPostgresProfile with PgStringSupport {
     override val api: API = new API {}
@@ -25,7 +25,7 @@ class PgStringSupportSuite extends FunSuite {
   ///
   import MyPostgresProfile1.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class StrBean(id: Long, str: String, strArr: Array[Byte])
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/trgm/PgTrgmSupportSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/trgm/PgTrgmSupportSuite.scala
@@ -1,7 +1,7 @@
 package com.github.tminglei.slickpg
 package trgm
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -9,7 +9,7 @@ import scala.concurrent.duration.Duration
 /**
   * Created by minglei on 6/21/17.
   */
-class PgTrgmSupportSuite extends FunSuite {
+class PgTrgmSupportSuite extends AnyFunSuite with PostgresContainer {
 
   trait MyPostgresProfile1 extends ExPostgresProfile with PgTrgmSupport {
     override val api: API = new API {}
@@ -22,7 +22,7 @@ class PgTrgmSupportSuite extends FunSuite {
   ///
   import MyPostgresProfile1.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class StrBean(id: Long, str: String)
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/utils/JsonUtilsSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/utils/JsonUtilsSuite.scala
@@ -1,8 +1,8 @@
 package com.github.tminglei.slickpg.utils
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class JsonUtilsSuite extends FunSuite {
+class JsonUtilsSuite extends AnyFunSuite {
   import JsonUtils._
 
   test("clean") {

--- a/core/src/test/scala/com/github/tminglei/slickpg/utils/PgTokenHelperSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/utils/PgTokenHelperSuite.scala
@@ -1,9 +1,9 @@
 package com.github.tminglei.slickpg
 package utils
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class PgTokenHelperSuite extends FunSuite {
+class PgTokenHelperSuite extends AnyFunSuite {
   import PgTokenHelper._
 
   test("tokenize") {

--- a/core/src/test/scala/com/github/tminglei/slickpg/utils/SimpleArrayUtilsSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/utils/SimpleArrayUtilsSuite.scala
@@ -1,8 +1,8 @@
 package com.github.tminglei.slickpg.utils
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SimpleArrayUtilsSuite extends FunSuite {
+class SimpleArrayUtilsSuite extends AnyFunSuite {
 
   test("fromString") {
     val v1 = SimpleArrayUtils.fromString(identity)("""{)}""")

--- a/src/test/scala/com/github/tminglei/slickpg/PgArraySupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgArraySupportSuite.scala
@@ -3,14 +3,14 @@ package com.github.tminglei.slickpg
 import java.sql.{Date, Time, Timestamp}
 import java.util.UUID
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.GetResult
 
 import scala.collection.mutable.Buffer
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class PgArraySupportSuite extends FunSuite {
+class PgArraySupportSuite extends AnyFunSuite with PostgresContainer {
   import utils.SimpleArrayUtils._
 
   //-- additional definitions
@@ -50,7 +50,7 @@ class PgArraySupportSuite extends FunSuite {
   //////////////////////////////////////////////////////////////////////////
   import MyPostgresProfile1.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class ArrayBean(
     id: Long,

--- a/src/test/scala/com/github/tminglei/slickpg/PgCompositeSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgCompositeSupportSuite.scala
@@ -1,7 +1,7 @@
 package com.github.tminglei.slickpg
 
 import org.postgresql.util.HStoreConverter
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.{GetResult, PositionedResult, PostgresProfile}
 
 import scala.collection.JavaConverters._
@@ -114,11 +114,11 @@ object PgCompositeSupportSuite {
 }
 
 ///
-class PgCompositeSupportSuite extends FunSuite {
+class PgCompositeSupportSuite extends AnyFunSuite with PostgresContainer {
   import PgCompositeSupportSuite._
   import MyPostgresProfile1.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class TestBean(
     id: Long,

--- a/src/test/scala/com/github/tminglei/slickpg/PgDate2SupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgDate2SupportSuite.scala
@@ -3,15 +3,15 @@ package com.github.tminglei.slickpg
 import java.time._
 import java.util.TimeZone
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.GetResult
 
 import scala.concurrent.Await
 
-class PgDate2SupportSuite extends FunSuite {
+class PgDate2SupportSuite extends AnyFunSuite with PostgresContainer {
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class DatetimeBean(
     id: Long,

--- a/src/test/scala/com/github/tminglei/slickpg/PgDateSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgDateSupportSuite.scala
@@ -6,15 +6,15 @@ import java.text.SimpleDateFormat
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class PgDateSupportSuite extends FunSuite {
+class PgDateSupportSuite extends AnyFunSuite with PostgresContainer {
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
   val timeFormat = new SimpleDateFormat("HH:mm:ss")

--- a/src/test/scala/com/github/tminglei/slickpg/PgEnumSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgEnumSupportSuite.scala
@@ -1,12 +1,12 @@
 package com.github.tminglei.slickpg
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.PostgresProfile
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class PgEnumSupportSuite extends FunSuite {
+class PgEnumSupportSuite extends AnyFunSuite with PostgresContainer {
   object WeekDays extends Enumeration {
     type WeekDay = Value
     val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
@@ -83,7 +83,7 @@ class PgEnumSupportSuite extends FunSuite {
   ////////////////////////////////////////////////////////////////////
   import MyPostgresProfile1.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class TestEnumBean(
     id: Long,

--- a/src/test/scala/com/github/tminglei/slickpg/PgHStoreSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgHStoreSupportSuite.scala
@@ -1,15 +1,15 @@
 package com.github.tminglei.slickpg
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.GetResult
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class PgHStoreSupportSuite extends FunSuite {
+class PgHStoreSupportSuite extends AnyFunSuite with PostgresContainer {
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class MapBean(id: Long, hstore: Map[String, String])
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgJsonSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgJsonSupportSuite.scala
@@ -1,16 +1,16 @@
 package com.github.tminglei.slickpg
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import slick.jdbc.GetResult
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class PgJsonSupportSuite extends FunSuite {
+class PgJsonSupportSuite extends AnyFunSuite with PostgresContainer {
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class JsonBean(id: Long, json: JsonString)
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgLTreeSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgLTreeSupportSuite.scala
@@ -1,16 +1,16 @@
 package com.github.tminglei.slickpg
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import slick.jdbc.GetResult
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class PgLTreeSupportSuite extends FunSuite {
+class PgLTreeSupportSuite extends AnyFunSuite with PostgresContainer {
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class LTreeBean(id: Long, path: LTree, treeArr: List[LTree])
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgNetSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgNetSupportSuite.scala
@@ -1,16 +1,16 @@
 package com.github.tminglei.slickpg
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import slick.jdbc.GetResult
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class PgNetSupportSuite extends FunSuite {
+class PgNetSupportSuite extends AnyFunSuite with PostgresContainer {
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class NetBean(id: Long, inet: InetString, mac: Option[MacAddrString] = None)
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgRangeSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgRangeSupportSuite.scala
@@ -3,16 +3,16 @@ package com.github.tminglei.slickpg
 import java.sql.Timestamp
 import java.time.{LocalDate, LocalDateTime, OffsetDateTime}
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.GetResult
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class PgRangeSupportSuite extends FunSuite {
+class PgRangeSupportSuite extends AnyFunSuite with PostgresContainer {
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   val tsFormatter = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
   def ts(str: String) = new Timestamp(tsFormatter.parse(str).getTime)

--- a/src/test/scala/com/github/tminglei/slickpg/PgSearchSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgSearchSupportSuite.scala
@@ -1,15 +1,15 @@
 package com.github.tminglei.slickpg
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.GetResult
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class PgSearchSupportSuite extends FunSuite {
+class PgSearchSupportSuite extends AnyFunSuite with PostgresContainer {
   import MyPostgresProfile.api._
 
-  val db = Database.forURL(url = utils.dbUrl, driver = "org.postgresql.Driver")
+  lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
   case class TestBean(id: Long, text: String, search: TsVector, comment: String)
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgTsqlSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgTsqlSupportSuite.scala
@@ -2,16 +2,17 @@ package com.github.tminglei.slickpg
 
 import java.util.UUID
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import slick.basic.StaticDatabaseConfig
 
 /*
  * NOTE: to check it, we need move `MyPostgresDriver.scala` from test folder to main folder
  */
 //@StaticDatabaseConfig("file:src/test/resources/application.conf#tsql")
-//class PgTsqlSupportSuite extends FunSuite {
-//
-//  test("tsql support - simple") {
+class PgTsqlSupportSuite extends AnyFunSuite {
+
+  test("tsql support - simple") {
+    pending
 //    import MyPostgresProfile.plainAPI._
 //
 //    /*
@@ -43,5 +44,5 @@ import slick.basic.StaticDatabaseConfig
 //    // NOTE: `pg type map to scala type with type parameter` was not supported by `slick`
 ////    val sql2: DBIO[Seq[(Long, Seq[UUID], Map[String, String], JsonString, LTree, Range[Float], Seq[Long])]] =
 ////      tsql"select * from tsql_test"
-//  }
-//}
+  }
+}


### PR DESCRIPTION
## Purpose
- Updates scala versions
  - `2.12.12` -> `2.12.13`
  - `2.13.3` -> `2.13.5`
- Updates core dependencies
  - postgresql driver
    - `42.2.14` -> `42.2.19`
  - slf4j-simple
    - `1.7.24` -> `1.7.30`
  - scalatest
    - `3.0.8` -> `3.2.7`
- Updates addon versions
  - joda-time
    - `2.10.5` -> `2.10.10`
  - json4s
    - `3.6.6` -> `3.6.11`
  - jts-lt
    - `1.16.1` -> `1.18.1`
  - play-json
    - `2.7.4` -> `2.9.2`; 2.12.x and 2.13.x only
  - spray-json
    - `1.3.5` -> `1.3.6`
  - circe
    - `0.12.3` -> `0.13.0`; 2.12.x and 2.13.x only
  - argonaut
    - `6.2.3` -> `6.2.5`; 2.11.x only
    - `6.2.3` -> `6.3.3`; 2.12.x and 2.13.x only
  - jawn
    - `0.14.2` -> `0.14.3`; 2.11.x only
    - `0.14.2` -> `1.1.1`; 2.12.x and 2.13.x only
- Adds [testcontainers](https://github.com/testcontainers/testcontainers-scala) postgresql module in favor of testing against a local postgresql server.
- Adds common PostgresContainer fixture trait that all tests can depend upon

## Background
I was looking to update the play-json addon to the latest version, but wasn't able to run the tests locally due to the dependency on a local postgres server. To work around this, I added the postgresql testcontainers module and a helper trait so that a fresh postgres container is started for each test suite. This has the benefit of making it easier to test against specific postgres versions and also ensures that tests are not dependent on one another. After doing this work, it wasn't much work to update the other addon modules and core dependencies, so took the liberty to update and test those aswell.

Thanks for the awesome lib, we use it in many of our projects! :smile: