### PR TITLE
Reproduce composite parsing bug

### DIFF
--- a/core/src/main/scala/com/github/tminglei/slickpg/utils/PgTokenHelper.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/utils/PgTokenHelper.scala
@@ -250,6 +250,11 @@ object PgTokenHelper {
           stack.top.tokens += Comma += Null
           groupForward(stack, sep2 :: tail)
 
+        // for open characters in strings
+        case Chunk(c) :: Open(o) :: tail => 
+          stack.top.tokens += Chunk(c + o)
+          groupForward(stack, tail)
+
         // for diggable
         case (head: Border) :: tail if !stack.top.isInChunk && isDiggable(stack.top, head, tail, diggResultRef) =>
           val (open, marker, escaped, tails) = diggResultRef.get()

--- a/src/main/scala/com/github/tminglei/slickpg/PgCompositeSupport.scala
+++ b/src/main/scala/com/github/tminglei/slickpg/PgCompositeSupport.scala
@@ -4,6 +4,7 @@ import scala.reflect.runtime.{universe => u}
 import scala.reflect.ClassTag
 import composite.Struct
 import slick.jdbc.{PositionedResult, PostgresProfile}
+import scala.annotation.tailrec
 
 trait PgCompositeSupport extends utils.PgCommonJdbcTypes with array.PgArrayJdbcTypes { driver: PostgresProfile =>
 
@@ -165,7 +166,17 @@ class PgCompositeSupportUtils(cl: ClassLoader, emptyMembersAsNull: Boolean) {
 
   case class SeqConverter(delegate: TokenConverter) extends TokenConverter {
     def fromToken(token: Token): Any =
-      if (token == Null) null else getChildren(token).map(delegate.fromToken)
+      if (token == Null) null else {
+        @tailrec
+        def smush(soFar: Seq[Token], remaining: Seq[Token]): Seq[Token] = (soFar, remaining) match {
+          case (tokens, Seq()) => tokens
+          case (Seq(), head +: tail) => smush(Seq(head), tail)
+          case (lead :+ Chunk(prefix), Chunk(suffix) +: tail) => smush(lead :+ Chunk(prefix + suffix), tail)
+          case (lead, middle +: tail) => smush(lead :+ middle, tail)
+        }
+        val smushed = smush(Vector.empty, (token.asInstanceOf[GroupToken]).members)
+        getChildren(GroupToken(smushed)).map(delegate.fromToken)
+      }
     def toToken(value: Any): Token = value match {
       case vList: Seq[Any] => {
         val members = Open("{") +: vList.map(delegate.toToken) :+ Close("}")

--- a/src/test/scala/com/github/tminglei/slickpg/PgCompositeSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgCompositeSupportSuite.scala
@@ -182,7 +182,7 @@ class PgCompositeSupportSuite extends AnyFunSuite with PostgresContainer {
     Some(Range(ts("2011-01-01T14:30:00"), ts("2011-11-01T15:30:00")))), false, Map("t't" -> "1,363"))))
   val rec3 = TestBean(337, List(Composite2(203, Composite1(103, "getRate(\"x\") + 5;", ts("2015-03-08T17:17:03"),
     None), false, Map("t,t" -> "getRate(\"x\") + 5;"))))
-  val rec4 = TestBean(339, List(Composite2(204, Composite1(104, "xxx(yyy)zz,z", ts("2001-01-03T13:21:00"),
+  val rec4 = TestBean(339, List(Composite2(204, Composite1(104, "x=1&y=2&[INSERT_DEVICE_ID_HERE]&z=3", ts("2001-01-03T13:21:00"),
     Some(Range(ts("2010-01-01T14:30:00"), ts("2010-01-03T15:30:00")))), true, Map("t" -> "haha", "t2" -> "133"))))
 
   val rec11 = TestBean1(111, List(Composite3(Some("(test1'"))))

--- a/src/test/scala/com/github/tminglei/slickpg/PgCompositeSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgCompositeSupportSuite.scala
@@ -197,7 +197,7 @@ class PgCompositeSupportSuite extends AnyFunSuite with PostgresContainer {
   val rec31 = TestBean3(1, None)
   val rec32 = TestBean3(2, Some(Composite4(1, "x1", Nil, Some(List.empty), "get(\"x1\").ok", "(4).ok")))
   val rec32_al = TestBean3(2, Some(Composite4(1, "x1", Nil, None, "get(\"x1\").ok", "(4).ok")))
-  val rec33 = TestBean3(3, Some(Composite4(2, "x2", List("A", "B"), Some(List("\"t")), "(get(\"A\") + get(\"A\")).ok", "call(A, B).ok")))
+  val rec33 = TestBean3(3, Some(Composite4(2, "x2", List("xxx(yyy)zz,z", "u(vv)w", "x=1&y=2&[INSERT_DEVICE_ID_HERE]&z=3"), Some(List("\"t")), "(get(\"A\") + get(\"A\")).ok", "call(A, B).ok")))
 
   test("Composite type Lifted support") {
     Await.result(db.run(

--- a/src/test/scala/com/github/tminglei/slickpg/PgCompositeSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgCompositeSupportSuite.scala
@@ -182,6 +182,8 @@ class PgCompositeSupportSuite extends AnyFunSuite with PostgresContainer {
     Some(Range(ts("2011-01-01T14:30:00"), ts("2011-11-01T15:30:00")))), false, Map("t't" -> "1,363"))))
   val rec3 = TestBean(337, List(Composite2(203, Composite1(103, "getRate(\"x\") + 5;", ts("2015-03-08T17:17:03"),
     None), false, Map("t,t" -> "getRate(\"x\") + 5;"))))
+  val rec4 = TestBean(339, List(Composite2(204, Composite1(104, "xxx(yyy)zz,z", ts("2001-01-03T13:21:00"),
+    Some(Range(ts("2010-01-01T14:30:00"), ts("2010-01-03T15:30:00")))), true, Map("t" -> "haha", "t2" -> "133"))))
 
   val rec11 = TestBean1(111, List(Composite3(Some("(test1'"))))
   val rec12 = TestBean1(112, List(Composite3(code = Some(102))))
@@ -209,7 +211,7 @@ class PgCompositeSupportSuite extends AnyFunSuite with PostgresContainer {
         sqlu"create type c1 as (name text)",
         sqlu"create type c2 as (c1 c1[])",
         (CompositeTests.schema ++ CompositeTests1.schema ++ CompositeTests2.schema ++ CompositeTests3.schema) create,
-        CompositeTests forceInsertAll List(rec1, rec2, rec3),
+        CompositeTests forceInsertAll List(rec1, rec2, rec3, rec4),
         CompositeTests1 forceInsertAll List(rec11, rec12, rec13, rec14, rec15),
         CompositeTests2 forceInsertAll List(rec21, rec22),
         CompositeTests3 forceInsertAll List(rec31, rec32, rec33)
@@ -223,6 +225,9 @@ class PgCompositeSupportSuite extends AnyFunSuite with PostgresContainer {
           ),
           CompositeTests.filter(_.id === 337L.bind).result.head.map(
             r => assert(rec3 === r)
+          ),
+          CompositeTests.filter(_.id === 339L.bind).result.head.map(
+            r => assert(rec4 === r)
           )
         )
       ).andThen(


### PR DESCRIPTION
There are bugs when using `()[]` characters in an array column in a composite type.
This PR reproduces, I'll poke around at fixing but if I don't get it done than hopefully someone else can take it from here.

For the failing test case, the column that needs to be parsed is
`(2,x2,"{""xxx(yyy)zz,z"",u(vv)w,x=1&y=2&[INSERT_DEVICE_ID_HERE]&z=3}","{""\\""t""}","(get(""A"") + get(""A"")).ok","call(A, B).ok")`

which tokenizes as
`Open((), Chunk(2), Comma, Chunk(x2), Comma, Marker("), Open({), Marker(""), Chunk(xxx), Open((), Chunk(yyy), Close()), Chunk(zz), Comma, Chunk(z), Marker(""), Comma, Chunk(u), Open((), Chunk(vv), Close()), Chunk(w), Comma, Chunk(x=1&y=2&), Open([), Chunk(INSERT_DEVICE_ID_HERE), Close(]), Chunk(&z=3), Close(}), Marker("), Comma, Marker("), Open({), Marker(""\\""), Chunk(t), Marker(""), Close(}), Marker("), Comma, Marker("), Open((), Chunk(get), Open((), Marker(""), Chunk(A), Marker(""), Close()), Chunk( + get), Open((), Marker(""), Chunk(A), Marker(""), Close()), Close()), Chunk(.ok), Marker("), Comma, Marker("), Chunk(call), Open((), Chunk(A), Comma, Chunk( B), Close()), Chunk(.ok), Marker("), Close())`
which looks fine

I think the trouble is in the token grouping
that problematic array groups(with a couple notes) as
```
GroupToken(
  Marker("),Open({),
  GroupToken(
    Marker(""),Chunk(xxx),Chunk((),Chunk(yyy),Chunk()),Chunk(zz),Comma,Chunk(z),Marker("")
                                                                 ^ should this be a Chunk(,)?
  ),
  Comma,Chunk(u),
  GroupToken(
    Marker(),Open((),Chunk(vv),Close()),Marker()
                  ^ should this be a chunk?
  ),
  Chunk(w),Comma,Chunk(x=1&y=2&),
  GroupToken(
    Marker(),Open([),Chunk(INSERT_DEVICE_ID_HERE),Close(]),Marker()
  ),
  Chunk(&z=3),
  Close(}),Marker(")
)
```
seems like there should be nothing but chunks between commas in a text array