### PR TITLE
Token smushing in O(n)

### DIFF
--- a/core/src/main/scala/com/github/tminglei/slickpg/utils/PgTokenHelper.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/utils/PgTokenHelper.scala
@@ -79,15 +79,14 @@ object PgTokenHelper {
   }
 
   @tailrec
-  private def smush(soFar: List[Token], remaining: Seq[Token]): Seq[Token] = (soFar, remaining) match {
-    case (tokens, Nil)                                  => tokens
-    case (empty, head +: tail) if empty.isEmpty         => smush(List(head), tail)
+  private def smush(soFar: Vector[Token], remaining: Seq[Token]): List[Token] = (soFar, remaining) match {
+    case (tokens, empty)       if empty.isEmpty         => tokens.toList
     case (lead :+ Chunk(prefix), Chunk(suffix) +: tail) => smush(lead :+ Chunk(prefix + suffix), tail)
     case (lead, middle +: tail)                         => smush(lead :+ middle, tail)
   }
-  
+
   def getChildren(token: Token): Seq[Token] = token match {
-    case GroupToken(mList) => smush(Nil, mList)
+    case GroupToken(mList) => smush(Vector.empty, mList)
       .filterNot(t => t == null || t.isInstanceOf[Border] || t == Comma)
     case _ => throw new IllegalArgumentException("WRONG token type: " + token)
   }


### PR DESCRIPTION
Basically reverting https://github.com/tminglei/slick-pg/commit/79f39bacdc4faff0fbc12dec1dd65b66b1694f3e from #512 

`soFar` really does need to be a collection with efficient `.last` and `.append`, because otherwise every `:+` is its own O(n) operation. We (at tubi.tv) found that the performance hit (with `List`) was too severe for production usage.

Alternatively if `List` is used then the recursive function needs to be refactored to [build `soFar` in reverse](https://github.com/tminglei/slick-pg/compare/master...adRise:no-shame#)