### PR TITLE
Rename implicit defs in PgTrmImplicits to avoid collision with PgStringImplicits

### DIFF
--- a/core/src/main/scala/com/github/tminglei/slickpg/trgm/PgTrgmSupport.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/trgm/PgTrgmSupport.scala
@@ -10,7 +10,7 @@ trait PgTrgmSupport extends PgTrgmExtensions { driver: PostgresProfile =>
   import driver.api._
 
   trait PgTrgmImplicits {
-    implicit def pgStringColumnExtensionMethods(c: Rep[String]) = new PgTrgmColumnExtensionMethods[String](c)
-    implicit def pgStringOptionColumnExtensionMethods(c: Rep[Option[String]]) = new PgTrgmColumnExtensionMethods[Option[String]](c)
+    implicit def pgTrgmColumnExtensionMethods(c: Rep[String]) = new PgTrgmColumnExtensionMethods[String](c)
+    implicit def pgTrgmOptionColumnExtensionMethods(c: Rep[Option[String]]) = new PgTrgmColumnExtensionMethods[Option[String]](c)
   }
 }


### PR DESCRIPTION
This fixes a minor issue that I noticed when trying to use `PgTrgmImplicits` and `PgStringImplicits` in the same trait.

For example:

```scala
object BrokenProfile extends PgTrgmSupport with PgStringSupport with PostgresProfile {
  trait Implicits extends PgTrgmImplicits with PgStringImplicits
}
```

produces the compiler error:

```
[error]   implicit def pgStringColumnExtensionMethods(c: com.github.tminglei.slickpg.trgm.BrokenProfile.api.Rep[String]): com.github.tminglei.slickpg.trgm.BrokenProfile.PgTrgmColumnExtensionMethods[String] (defined in trait PgTrgmImplicits) and
[error]   implicit def pgStringColumnExtensionMethods(c: com.github.tminglei.slickpg.trgm.BrokenProfile.api.Rep[String]): com.github.tminglei.slickpg.trgm.BrokenProfile.PgStringColumnExtensionMethods[String] (defined in trait PgStringImplicits)
[error]   (note: this can be resolved by declaring an `override` in trait Implicits.);
[error]  other members with override errors are: pgStringOptionColumnExtensionMethods
[error]   trait Implicits extends PgTrgmImplicits with PgStringImplicits
```

Because `PgTrgmImplicits` and `PgStringImplicits` use the same names with the same signatures for their implicit conversion methods.

Maybe it was just a copy/paste oversight when creating PgTrgmImplicits? Regardless, this simple rename should fix it.

LMK if there's any additional testing that would be useful here. Maybe just a file profile that tries to combine all of the available implicit conversions would be useful.