### PR TITLE
Update vulnerable Postgres JDBC Driver; jump to v0.20.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,44 +194,44 @@ Install
 -------
 To use `slick-pg` in [sbt](http://www.scala-sbt.org/ "slick-sbt") project, add the following to your project file:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg" % "0.20.3"
+libraryDependencies += "com.github.tminglei" %% "slick-pg" % "0.20.4"
 ```
 
 > If you need `joda-time` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_joda-time" % "0.20.3"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_joda-time" % "0.20.4"
 ```
 
 > If you need `jts` geom support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_jts" % "0.20.3"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_jts" % "0.20.4"
 or
-libraryDependencies += "com.github.tminglei" %% "slick-pg_jts_lt" % "0.20.3"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_jts_lt" % "0.20.4"
 ```
 
 > If you need `json4s` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_json4s" % "0.20.3"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_json4s" % "0.20.4"
 ```
 
 > If you need `play-json` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_play-json" % "0.20.3"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_play-json" % "0.20.4"
 ```
 
 > If you need `spray-json` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_spray-json" % "0.20.3"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_spray-json" % "0.20.4"
 ```
 
 > If you need `argonaut json` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_argonaut" % "0.20.3"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_argonaut" % "0.20.4"
 ```
 
 > If you need `circe json` support, pls append dependency:
 ```scala
-libraryDependencies += "com.github.tminglei" %% "slick-pg_circe-json" % "0.20.3"
+libraryDependencies += "com.github.tminglei" %% "slick-pg_circe-json" % "0.20.4"
 ```
 
 
@@ -240,7 +240,7 @@ Or, in [maven](http://maven.apache.org/ "maven") project, you can add `slick-pg`
 <dependency>
     <groupId>com.github.tminglei</groupId>
     <artifactId>slick-pg_2.12</artifactId>
-    <version>0.20.3</version>
+    <version>0.20.4</version>
 </dependency>
 <!-- other addons if necessary -->
 ...

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val commonSettings = Seq(
   organizationName := "slick-pg",
   organization := "com.github.tminglei",
   name := "slick-pg",
-  version := "0.20.3",
+  version := "0.20.4",
 
   scalaVersion := scala213,
   crossScalaVersions := Seq(scala213, scala212, scala211),
@@ -72,7 +72,7 @@ def mainDependencies(scalaVersion: String) = {
   Seq (
     "org.scala-lang" % "scala-reflect" % scalaVersion,
     "com.typesafe.slick" %% "slick" % "3.3.3",
-    "org.postgresql" % "postgresql" % "42.2.19",
+    "org.postgresql" % "postgresql" % "42.4.1",
     "org.slf4j" % "slf4j-simple" % "1.7.30" % "provided",
     "org.scalatest" %% "scalatest" % "3.2.7" % "test",
     "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.39.3" % "test",


### PR DESCRIPTION
**Update Postgres JDBC Driver to 42.4.1**

Current 42.2.19 version of Postgres JDBC driver has vulnerability ([CVE-2022-21724](https://www.cvedetails.com/cve/CVE-2022-21724), [mvnrepository slick-pg 0.20.3](https://mvnrepository.com/artifact/com.github.tminglei/slick-pg_2.12/0.20.3)).


