### PR TITLE
Rollback scala-parser-combinators to 1.1.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val commonSettings = Seq(
 def mainDependencies(scalaVersion: String) = {
   val extractedLibs = CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-      Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.1")
+      Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2")
     case _ =>
       Seq()
   }


### PR DESCRIPTION
Should fix #586 upon publishing.