### PR TITLE
Add support for date_bin (available in postgres >= 14)

### DIFF
--- a/addons/joda-time/src/test/scala/com/github/tminglei/slickpg/PgDateSupportJodaSuite.scala
+++ b/addons/joda-time/src/test/scala/com/github/tminglei/slickpg/PgDateSupportJodaSuite.scala
@@ -145,6 +145,10 @@ class PgDateSupportJodaSuite extends AnyFunSuite with PostgresContainer {
           Datetimes.filter(_.id === 101L.bind).map(r => r.datetime.trunc("day")).result.head.map(
             r => assert(LocalDateTime.parse("2001-01-03T00:00:00") === r)
           ),
+          // dateBin
+         DBIO.seq(Option.when(pgVersion.take(2).toInt >= 14)(Datetimes.filter(_.id === 101L.bind).map(r => r.datetime.dateBin("1 hour", LocalDateTime.parse("2001-01-03T18:35:17"))).result.head.map(
+            r => assert(LocalDateTime.parse("2001-01-03T12:35:17") === r)
+          )).toSeq:_*),
           // isFinite
           Datetimes.filter(_.id === 101L.bind).map(r => r.datetime.isFinite).result.head.map(
             r => assert(true === r)
@@ -204,7 +208,11 @@ class PgDateSupportJodaSuite extends AnyFunSuite with PostgresContainer {
             // trunc
             Datetimes.filter(_.id === 101L.bind).map(r => r.datetimetz.trunc("day")).result.head.map(
               r => assert(DateTime.parse("2001-01-03 00:00:00.000+08", jodaTzDateTimeFormatter) === r)
-            )
+            ),
+            // dateBin
+            DBIO.seq(Option.when(pgVersion.take(2).toInt >= 14)(Datetimes.filter(_.id === 101L.bind).map(r => r.datetimetz.dateBin("1 hour", DateTime.parse("2001-01-02T18:35:17+08"))).result.head.map(
+              r => assert(DateTime.parse("2001-01-03 12:35:17.000+08", jodaTzDateTimeFormatter) === r)
+            )).toSeq:_*)
           ),
           // update and check
           DBIO.seq(

--- a/core/src/main/scala/com/github/tminglei/slickpg/date/PgDateExtensions.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/date/PgDateExtensions.scala
@@ -18,6 +18,7 @@ trait PgDateExtensions extends JdbcTypesComponent { driver: PostgresProfile =>
     val Age = new SqlFunction("age")
     val Part = new SqlFunction("date_part")
     val Trunc = new SqlFunction("date_trunc")
+    val DateBin = new SqlFunction("date_bin")
     val IsFinite = new SqlFunction("isfinite")
 
     val JustifyDays = new SqlFunction("justify_days")
@@ -64,6 +65,9 @@ trait PgDateExtensions extends JdbcTypesComponent { driver: PostgresProfile =>
       }
     def trunc[R](field: Rep[String])(implicit om: o#to[TIMESTAMP, R]) = {
         om.column(DateLibrary.Trunc, field.toNode, n)
+      }
+    def dateBin[R](step: Rep[String], base: Rep[TIMESTAMP])(implicit om: o#to[TIMESTAMP, R]) = {
+        om.column(DateLibrary.DateBin, step.toNode, n, base.toNode)
       }
     def isFinite[R](implicit om: o#to[Boolean, R]) = om.column(DateLibrary.IsFinite, n)
 

--- a/core/src/main/scala/com/github/tminglei/slickpg/date/README.md
+++ b/core/src/main/scala/com/github/tminglei/slickpg/date/README.md
@@ -1,28 +1,29 @@
 Supported Date/Time Oper/Functions
 ---------------------------------
 
-| Slick Oper/Function | PG Oper/Function |       Description       |                Example                         |           Result         |
-| ------------------- | ---------------- | ----------------------- | ---------------------------------------------- | ------------------------ |
-| +++                 | +                | timestamp + interval    | timestamp '2001-09-28 01:00' + interval '23 hours'|timestamp '2001-09-29 00:00:00'|
-| -                   | -                | timestamp - timestamp   | timestamp '2001-09-29 03:00' - timestamp '2001-09-27 12:00'|interval '1 day 15:00:00'|
-| --                  | -                | timestamp - time        | timestamp '2001-09-29 03:00' - time '03:00' | timestamp '2001-09-29 00:00'|
-| ---                 | -                | timestame - interval    | timestamp '2001-09-28 23:00' - interval '23 hours'|timestamp '2001-09-28 00:00:00'|
-| age                 | age              | age(timestamp[, timestamp])| age(timestamp '2001-04-10', timestamp '1957-06-13')|43 years 9 mons 27 days|
-| age                 | age              | age(timestamp)          | age(timestamp '1957-06-13')                    | 43 years 9 mons 27 days  |
-| part                | date_part/extract| date_part(text, timestamp) | date_part('hour', timestamp '2001-02-16 20:38:40') | 20                |
-| trunc               | date_trunc       | date_trunc(text, timestamp)| date_trunc('hour', timestamp '2001-02-16 20:38:40') | 2001-02-16 20:00:00 |
-| +                   | +                | date + time             | date '2001-09-28' + time '03:00'       | timestamp '2001-09-28 03:00:00'  |
-| ++                  | +                | date + int              | date '2001-10-01' - integer '7'        | date '2001-09-24'                |
-| +++                 | +                | date + interval         | date '2001-09-28' + interval '1 hour'  | timestamp '2001-09-28 01:00:00'  |
-| -                   | -                | date - date             | date '2001-10-01' - date '2001-09-28'  | integer '3' (days)               |
-| --                  | -                | date - int              | date '2001-10-01' - integer '7'        | date '2001-09-24'                |
-| ---                 | -                | date - interval         | date '2001-09-28' - interval '1 hour'  | timestamp '2001-09-27 23:00:00'  |
-| +                   | +                | time + date             | time '03:00' + date '2001-09-28'       | timestamp '2001-09-28 03:00:00'  |
-| +++                 | +                | time + interval         | time '05:00' - interval '2 hours'      | time '03:00:00'                  |
-| -                   | -                | time - time             | time '05:00' - time '03:00'            | interval '02:00:00'              |
-| ---                 | -                | time - interval         | time '05:00' - interval '2 hours'      | time '03:00:00'                  |
-| +                   | +                | interval + interval     | interval '1 day' + interval '1 hour'   | interval '1 day 01:00:00'        |
-| unary_-             | -                | - interval              | - interval '23 hours'                  | interval '-23:00:00'             |
-| -                   | -                | interval - interval     | interval '1 day' - interval '1 hour'   | interval '1 day -01:00:00'       |
-| *                   | *                | interval * factor       | double precision '3.5' * interval '1 hour'| interval '03:30:00'           |
-| /                   | /                | interval / factor       | interval '1 hour' / double precision '1.5'| interval '00:40:00'           |
+| Slick Oper/Function | PG Oper/Function  | Description                          | Example                                                                              | Result                          |
+|---------------------|-------------------|--------------------------------------|--------------------------------------------------------------------------------------|---------------------------------|
+| +++                 | +                 | timestamp + interval                 | timestamp '2001-09-28 01:00' + interval '23 hours'                                   | timestamp '2001-09-29 00:00:00' |
+| -                   | -                 | timestamp - timestamp                | timestamp '2001-09-29 03:00' - timestamp '2001-09-27 12:00'                          | interval '1 day 15:00:00'       |
+| --                  | -                 | timestamp - time                     | timestamp '2001-09-29 03:00' - time '03:00'                                          | timestamp '2001-09-29 00:00'    |
+| ---                 | -                 | timestame - interval                 | timestamp '2001-09-28 23:00' - interval '23 hours'                                   | timestamp '2001-09-28 00:00:00' |
+| age                 | age               | age(timestamp[, timestamp])          | age(timestamp '2001-04-10', timestamp '1957-06-13')                                  | 43 years 9 mons 27 days         |
+| age                 | age               | age(timestamp)                       | age(timestamp '1957-06-13')                                                          | 43 years 9 mons 27 days         |
+| part                | date_part/extract | date_part(text, timestamp)           | date_part('hour', timestamp '2001-02-16 20:38:40')                                   | 20                              |
+| trunc               | date_trunc        | date_trunc(text, timestamp)          | date_trunc('hour', timestamp '2001-02-16 20:38:40')                                  | 2001-02-16 20:00:00             |
+| dateBin             | date_bin          | date_bin(text, timestamp, timestamp) | date_bin('1 hour', timestamp '2001-02-16 20:38:40', timestamp '2001-02-16 18:35:17') | 2001-02-16 20:35:17             |
+| +                   | +                 | date + time                          | date '2001-09-28' + time '03:00'                                                     | timestamp '2001-09-28 03:00:00' |
+| ++                  | +                 | date + int                           | date '2001-10-01' - integer '7'                                                      | date '2001-09-24'               |
+| +++                 | +                 | date + interval                      | date '2001-09-28' + interval '1 hour'                                                | timestamp '2001-09-28 01:00:00' |
+| -                   | -                 | date - date                          | date '2001-10-01' - date '2001-09-28'                                                | integer '3' (days)              |
+| --                  | -                 | date - int                           | date '2001-10-01' - integer '7'                                                      | date '2001-09-24'               |
+| ---                 | -                 | date - interval                      | date '2001-09-28' - interval '1 hour'                                                | timestamp '2001-09-27 23:00:00' |
+| +                   | +                 | time + date                          | time '03:00' + date '2001-09-28'                                                     | timestamp '2001-09-28 03:00:00' |
+| +++                 | +                 | time + interval                      | time '05:00' - interval '2 hours'                                                    | time '03:00:00'                 |
+| -                   | -                 | time - time                          | time '05:00' - time '03:00'                                                          | interval '02:00:00'             |
+| ---                 | -                 | time - interval                      | time '05:00' - interval '2 hours'                                                    | time '03:00:00'                 |
+| +                   | +                 | interval + interval                  | interval '1 day' + interval '1 hour'                                                 | interval '1 day 01:00:00'       |
+| unary_-             | -                 | - interval                           | - interval '23 hours'                                                                | interval '-23:00:00'            |
+| -                   | -                 | interval - interval                  | interval '1 day' - interval '1 hour'                                                 | interval '1 day -01:00:00'      |
+| *                   | *                 | interval * factor                    | double precision '3.5' * interval '1 hour'                                           | interval '03:30:00'             |
+| /                   | /                 | interval / factor                    | interval '1 hour' / double precision '1.5'                                           | interval '00:40:00'             |

--- a/src/test/scala/com/github/tminglei/slickpg/PgDate2SupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgDate2SupportSuite.scala
@@ -162,6 +162,10 @@ class PgDate2SupportSuite extends AnyFunSuite with PostgresContainer {
           Datetimes.filter(_.id === 101L.bind).map(r => r.dateTime.trunc("day")).result.head.map(
             r => assert(LocalDateTime.parse("2001-01-03T00:00:00") === r)
           ),
+          // dateBin
+          DBIO.seq(Option.when(pgVersion.take(2).toInt >= 14)(Datetimes.filter(_.id === 101L.bind).map(r => r.dateTime.dateBin("1 hour", LocalDateTime.parse("2001-01-03T18:35:17"))).result.head.map(
+            r => assert(LocalDateTime.parse("2001-01-03T12:35:17") === r)
+          )).toSeq:_*),
           // isFinite
           Datetimes.filter(_.id === 101L.bind).map(r => r.dateTime.isFinite).result.head.map(
             r => assert(true === r)
@@ -223,7 +227,11 @@ class PgDate2SupportSuite extends AnyFunSuite with PostgresContainer {
             ),
             Datetimes.filter(_.id === 101L.bind).map(r => r.dateTimeTz.trunc("day")).result.head.map(
               r => assert(ZonedDateTime.parse("2001-01-03 00:00:00+08", date2TzDateTimeFormatter) === r)
-            )
+            ),
+            // dateBin
+            DBIO.seq(Option.when(pgVersion.take(2).toInt >= 14)(Datetimes.filter(_.id === 101L.bind).map(r => r.dateTimeTz.dateBin("1 hour", ZonedDateTime.parse("2001-01-03 18:35:17+03", date2TzDateTimeFormatter))).result.head.map(
+              r => assert(ZonedDateTime.parse("2001-01-03 12:35:17+08", date2TzDateTimeFormatter) === r)
+            )).toSeq:_*)
           ),
           // Timezones
           Datetimes.filter(_.id === 101L.bind).map(r => r.zone).result.head.map(


### PR DESCRIPTION
I don't know what your take is on functions that're introduced in versions of postgres > 11 - I didn't spot anything similar in the repo already - but this is a pretty handy one, so I thought I might as well give it a shot.