### PR TITLE
make some tests compile with scala 3

### DIFF
--- a/addons/argonaut/src/test/scala/com/github/tminglei/slickpg/PgArgonautSupportSuite.scala
+++ b/addons/argonaut/src/test/scala/com/github/tminglei/slickpg/PgArgonautSupportSuite.scala
@@ -1,17 +1,16 @@
 package com.github.tminglei.slickpg
 
 import java.util.concurrent.Executors
-
 import argonaut.Argonaut._
 import argonaut._
 import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.{GetResult, PostgresProfile}
 
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService}
 import scala.concurrent.duration._
 
 class PgArgonautSupportSuite extends AnyFunSuite with PostgresContainer {
-  implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
+  implicit val testExecContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 
   trait MyPostgresProfile extends PostgresProfile
                             with PgArgonautSupport
@@ -24,7 +23,7 @@ class PgArgonautSupportSuite extends AnyFunSuite with PostgresContainer {
 
     ///
     trait API extends JdbcAPI with JsonImplicits {
-      implicit val strListTypeMapper = new SimpleArrayJdbcType[String]("text").to(_.toList)
+      implicit val strListTypeMapper: DriverJdbcType[List[JsonField]] = new SimpleArrayJdbcType[String]("text").to(_.toList)
     }
   }
   object MyPostgresProfile extends MyPostgresProfile
@@ -40,7 +39,7 @@ class PgArgonautSupportSuite extends AnyFunSuite with PostgresContainer {
     def id = column[Long]("id", O.AutoInc, O.PrimaryKey)
     def json = column[Json]("json")
 
-    def * = (id, json) <> (JsonBean.tupled, JsonBean.unapply)
+    def * = (id, json) <> ((JsonBean.apply _).tupled, JsonBean.unapply)
   }
   val JsonTests = TableQuery[JsonTestTable]
 
@@ -158,7 +157,7 @@ class PgArgonautSupportSuite extends AnyFunSuite with PostgresContainer {
   test("Argonaut json Plain SQL support") {
     import MyPostgresProfile.plainAPI._
 
-    implicit val getJsonBeanResult = GetResult(r => JsonBean(r.nextLong(), r.nextJson()))
+    implicit val getJsonBeanResult: GetResult[JsonBean] = GetResult(r => JsonBean(r.nextLong(), r.nextJson()))
 
     val b = JsonBean(34L, """ { "a":101, "b":"aaa", "c":[3,4,5,9] } """.parseOption.getOrElse(jNull))
 

--- a/addons/circe-json/src/test/scala/com/github/tminglei/slickpg/PgCirceJsonSupportSuite.scala
+++ b/addons/circe-json/src/test/scala/com/github/tminglei/slickpg/PgCirceJsonSupportSuite.scala
@@ -1,18 +1,17 @@
 package com.github.tminglei.slickpg
 
 import java.util.concurrent.Executors
-
 import cats.syntax.either._
 import io.circe._
 import io.circe.parser._
 import org.scalatest.funsuite.AnyFunSuite
 import slick.jdbc.{GetResult, PostgresProfile}
 
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService}
 import scala.concurrent.duration._
 
 class PgCirceJsonSupportSuite extends AnyFunSuite with PostgresContainer {
-  implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
+  implicit val testExecContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 
   trait MyPostgresProfile extends PostgresProfile
                             with PgCirceJsonSupport
@@ -25,7 +24,7 @@ class PgCirceJsonSupportSuite extends AnyFunSuite with PostgresContainer {
 
     ///
     trait API extends JdbcAPI with JsonImplicits {
-      implicit val strListTypeMapper = new SimpleArrayJdbcType[String]("text").to(_.toList)
+      implicit val strListTypeMapper: DriverJdbcType[List[String]] = new SimpleArrayJdbcType[String]("text").to(_.toList)
     }
   }
   object MyPostgresProfile extends MyPostgresProfile
@@ -40,7 +39,7 @@ class PgCirceJsonSupportSuite extends AnyFunSuite with PostgresContainer {
     def id = column[Long]("id", O.AutoInc, O.PrimaryKey)
     def json = column[Json]("json")
 
-    def * = (id, json) <> (JsonBean.tupled, JsonBean.unapply)
+    def * = (id, json) <> ((JsonBean.apply _).tupled, JsonBean.unapply)
   }
   val JsonTests = TableQuery[JsonTestTable]
 
@@ -137,7 +136,7 @@ class PgCirceJsonSupportSuite extends AnyFunSuite with PostgresContainer {
   test("Circe json Plain SQL support") {
     import MyPostgresProfile.plainAPI._
 
-    implicit val getJsonBeanResult = GetResult(r => JsonBean(r.nextLong(), r.nextJson()))
+    implicit val getJsonBeanResult: GetResult[JsonBean] = GetResult(r => JsonBean(r.nextLong(), r.nextJson()))
 
     val b = JsonBean(34L, parse(""" { "a":101, "b":"aaa", "c":[3,4,5,9] } """).getOrElse(Json.Null))
 

--- a/addons/jts/src/test/scala/com/github/tminglei/slickpg/PgPostGISSupportSuite.scala
+++ b/addons/jts/src/test/scala/com/github/tminglei/slickpg/PgPostGISSupportSuite.scala
@@ -1,19 +1,16 @@
 package com.github.tminglei.slickpg
 
 import java.util.concurrent.Executors
-
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext}
-
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService}
 import slick.jdbc.GetResult
-
 import com.vividsolutions.jts.geom.{Geometry, Point}
 import com.vividsolutions.jts.io.{WKBWriter, WKTReader, WKTWriter}
 import org.scalatest.funsuite.AnyFunSuite
 
 
 class PgPostGISSupportSuite extends AnyFunSuite with PostgresContainer {
-  implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
+  implicit val testExecContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 
   trait MyPostgresProfile extends ExPostgresProfile with PgPostGISSupport {
 
@@ -41,7 +38,7 @@ class PgPostGISSupportSuite extends AnyFunSuite with PostgresContainer {
     def geom = column[Geometry]("geom")
     def geog = column[Geography]("geog")
 
-    def * = (id, geom, geog) <> (GeometryBean.tupled, GeometryBean.unapply)
+    def * = (id, geom, geog) <> ((GeometryBean.apply _).tupled, GeometryBean.unapply)
   }
   val GeomTests = TableQuery[GeomTestTable]
 
@@ -52,7 +49,7 @@ class PgPostGISSupportSuite extends AnyFunSuite with PostgresContainer {
     def id = column[Long]("id", O.AutoInc, O.PrimaryKey)
     def point = column[Point]("point")
 
-    def * = (id, point) <> (PointBean.tupled, PointBean.unapply)
+    def * = (id, point) <> ((PointBean.apply _).tupled, PointBean.unapply)
   }
   val PointTests = TableQuery[PointTestTable]
 
@@ -830,7 +827,7 @@ class PgPostGISSupportSuite extends AnyFunSuite with PostgresContainer {
   test("PostGIS Plain SQL support") {
     import MyPostgresProfile.plainAPI._
 
-    implicit val GetPointBeanResult = GetResult(r => PointBean(r.nextLong(), r.nextGeometry[Point]()))
+    implicit val GetPointBeanResult: GetResult[PointBean] = GetResult(r => PointBean(r.nextLong(), r.nextGeometry[Point]()))
 
     val b = PointBean(77L, wktReader.read("POINT(4 5)").asInstanceOf[Point])
 

--- a/addons/play-json/src/test/scala/com/github/tminglei/slickpg/PgPlayJsonSupportSuite.scala
+++ b/addons/play-json/src/test/scala/com/github/tminglei/slickpg/PgPlayJsonSupportSuite.scala
@@ -1,24 +1,22 @@
 package com.github.tminglei.slickpg
 
 import java.util.concurrent.Executors
-
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext}
-
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService}
 import play.api.libs.json._
-import slick.jdbc.{GetResult, PostgresProfile}
-
+import slick.jdbc.{GetResult, JdbcType, PostgresProfile}
 import com.github.tminglei.slickpg.utils.JsonUtils
 import org.scalatest.funsuite.AnyFunSuite
+import slick.ast.BaseTypedType
 
 
 class PgPlayJsonSupportSuite extends AnyFunSuite with PostgresContainer {
-  implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
+  implicit val testExecContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 
   case class JBean(name: String, count: Int)
   object JBean {
-    implicit val jbeanFmt = Json.format[JBean]
-    implicit val jbeanWrt = Json.writes[JBean]
+    implicit val jbeanFmt: OFormat[JBean] = Json.format[JBean]
+    implicit val jbeanWrt: OWrites[JBean] = Json.writes[JBean]
   }
 
   trait MyPostgresProfile extends PostgresProfile
@@ -32,14 +30,14 @@ class PgPlayJsonSupportSuite extends AnyFunSuite with PostgresContainer {
 
     ///
     trait API extends JdbcAPI with JsonImplicits {
-      implicit val strListTypeMapper = new SimpleArrayJdbcType[String]("text").to(_.toList)
-      implicit val beanJsonTypeMapper = MappedJdbcType.base[JBean, JsValue](Json.toJson(_), _.as[JBean])
-      implicit val jsonArrayTypeMapper =
+      implicit val strListTypeMapper: DriverJdbcType[List[String]] = new SimpleArrayJdbcType[String]("text").to(_.toList)
+      implicit val beanJsonTypeMapper: JdbcType[JBean] with BaseTypedType[JBean] = MappedJdbcType.base[JBean, JsValue](Json.toJson(_), _.as[JBean])
+      implicit val jsonArrayTypeMapper: DriverJdbcType[List[JsValue]] =
         new AdvancedArrayJdbcType[JsValue](pgjson,
           (s) => utils.SimpleArrayUtils.fromString[JsValue](Json.parse(_))(s).orNull,
           (v) => utils.SimpleArrayUtils.mkString[JsValue](_.toString())(v)
         ).to(_.toList)
-      implicit val beanArrayTypeMapper =
+      implicit val beanArrayTypeMapper: DriverJdbcType[List[JBean]] =
         new AdvancedArrayJdbcType[JBean](pgjson,
           (s) => utils.SimpleArrayUtils.fromString[JBean](Json.parse(_).as[JBean])(s).orNull,
           (v) => utils.SimpleArrayUtils.mkString[JBean](b => Json.stringify(Json.toJson(b)))(v)
@@ -62,7 +60,7 @@ class PgPlayJsonSupportSuite extends AnyFunSuite with PostgresContainer {
     def jbean = column[JBean]("jbean")
     def jbeans = column[List[JBean]]("jbeans")
 
-    def * = (id, json, jsons, jbean, jbeans) <> (JsonBean.tupled, JsonBean.unapply)
+    def * = (id, json, jsons, jbean, jbeans) <> ((JsonBean.apply _).tupled, JsonBean.unapply)
   }
   val JsonTests = TableQuery[JsonTestTable]
 
@@ -207,7 +205,7 @@ class PgPlayJsonSupportSuite extends AnyFunSuite with PostgresContainer {
   test("Json Plain SQL support") {
     import MyPostgresProfile.plainAPI._
 
-    implicit val getJsonBeanResult = GetResult(r => JsonBean1(r.nextLong(), r.nextJson()))
+    implicit val getJsonBeanResult: GetResult[JsonBean1] = GetResult(r => JsonBean1(r.nextLong(), r.nextJson()))
 
     val b = JsonBean1(34L, Json.parse(""" { "a":101, "b":"aaa", "c":[3,4,5,9] } """))
 

--- a/core/src/main/scala/com/github/tminglei/slickpg/lobj/LargeObjectStreamingDBIOAction.scala
+++ b/core/src/main/scala/com/github/tminglei/slickpg/lobj/LargeObjectStreamingDBIOAction.scala
@@ -14,7 +14,7 @@ import slick.util.DumpInfo
   * @param largeObjectId The oid of the LargeObject to stream.
   * @param bufferSize The chunk size in bytes. Default to 8KB.
   */
-case class LargeObjectStreamingDBIOAction(largeObjectId: Long, bufferSize: Int = 1024 * 8)
+case class LargeObjectStreamingDBIOAction(largeObjectId: Long, bufferSize: Int = 1024 * 8)(implicit proof: JdbcBackend#StreamingContext <:< JdbcBackend#Context)
   extends SynchronousDatabaseAction[
     Array[Byte],
     Streaming[Array[Byte]],
@@ -78,8 +78,8 @@ case class LargeObjectStreamingDBIOAction(largeObjectId: Long, bufferSize: Int =
     */
   override def emitStream(context: JdbcBackend#StreamingContext, limit: Long, state: StreamState): StreamState = {
     //open the stream iff no stream state exists
-    val (stream, previousBytesRead) = state == null match {
-      case true => (openObject(context), 1)
+    val (stream, previousBytesRead) = (state == null) match {
+      case true => (openObject(proof(context)), 1)
       case false => state
     }
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgAggFuncCoreSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgAggFuncCoreSuite.scala
@@ -22,7 +22,7 @@ class PgAggFuncCoreSuite extends AnyFunSuite with PostgresContainer {
     def x = column[Double]("x")
     def y = column[Double]("y")
 
-    def * = (name, count, x, y) <> (Tab.tupled, Tab.unapply)
+    def * = (name, count, x, y) <> ((Tab.apply _).tupled, Tab.unapply)
   }
   val tabs = TableQuery(new Tabs(_))
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgAggFuncSupportSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgAggFuncSupportSuite.scala
@@ -9,9 +9,9 @@ class PgAggFuncSupportSuite extends AnyFunSuite with PostgresContainer {
   import ExPostgresProfile.api._
 
   val PgArrayJdbcTypes = new array.PgArrayJdbcTypes with ExPostgresProfile {}
-  implicit val simpleIntListTypeMapper = new PgArrayJdbcTypes.SimpleArrayJdbcType[Int]("int4").to(_.toList)
-  implicit val simpleStrListTypeMapper = new PgArrayJdbcTypes.SimpleArrayJdbcType[String]("text").to(_.toList)
-  implicit val simpleDoubleListTypeMapper = new PgArrayJdbcTypes.SimpleArrayJdbcType[Double]("float8").to(_.toList)
+  implicit val simpleIntListTypeMapper: PgArrayJdbcTypes.DriverJdbcType[List[Int]] = new PgArrayJdbcTypes.SimpleArrayJdbcType[Int]("int4").to(_.toList)
+  implicit val simpleStrListTypeMapper: PgArrayJdbcTypes.DriverJdbcType[List[String]] = new PgArrayJdbcTypes.SimpleArrayJdbcType[String]("text").to(_.toList)
+  implicit val simpleDoubleListTypeMapper: PgArrayJdbcTypes.DriverJdbcType[List[Double]] = new PgArrayJdbcTypes.SimpleArrayJdbcType[Double]("float8").to(_.toList)
 
   lazy val db = Database.forURL(url = container.jdbcUrl, driver = "org.postgresql.Driver")
 
@@ -24,7 +24,7 @@ class PgAggFuncSupportSuite extends AnyFunSuite with PostgresContainer {
     def x = column[Double]("x")
     def y = column[Double]("y")
 
-    def * = (name, count, bool, x, y) <> (Tab.tupled, Tab.unapply)
+    def * = (name, count, bool, x, y) <> ((Tab.apply _).tupled, Tab.unapply)
   }
   val tabs = TableQuery(new Tabs(_))
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgAutoIncSeqColumnSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgAutoIncSeqColumnSuite.scala
@@ -16,7 +16,7 @@ class PgAutoIncSeqColumnSuite extends AnyFunSuite with PostgresContainer {
 
     def name = column[String]("name")
 
-    def * = (id, name) <> (User.tupled, User.unapply)
+    def * = (id, name) <> ((User.apply _).tupled, User.unapply)
   }
 
   val AutoIncSeqTests = TableQuery[AutoIncSeqTestTable]
@@ -26,7 +26,7 @@ class PgAutoIncSeqColumnSuite extends AnyFunSuite with PostgresContainer {
 
     def name = column[String]("name")
 
-    def * = (id, name) <> (User.tupled, User.unapply)
+    def * = (id, name) <> ((User.apply _).tupled, User.unapply)
   }
 
   val AutoIncSeqNameTests = TableQuery[AutoIncSeqNameTestTable]
@@ -36,7 +36,7 @@ class PgAutoIncSeqColumnSuite extends AnyFunSuite with PostgresContainer {
 
     def name = column[String]("name")
 
-    def * = (id, name) <> (User.tupled, User.unapply)
+    def * = (id, name) <> ((User.apply _).tupled, User.unapply)
   }
 
   val AutoIncSeqFnTests = TableQuery[AutoIncSeqFnTestTable]
@@ -53,7 +53,7 @@ class PgAutoIncSeqColumnSuite extends AnyFunSuite with PostgresContainer {
 
     def name = column[String]("name")
 
-    def * = (id, name) <> (User.tupled, User.unapply)
+    def * = (id, name) <> ((User.apply _).tupled, User.unapply)
   }
 
   val AutoIncSeqNameWithFnTests = TableQuery[AutoIncSeqNameWithFnTestTable]

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgInheritsSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgInheritsSuite.scala
@@ -20,7 +20,7 @@ class PgInheritsSuite extends AnyFunSuite with PostgresContainer {
   case class Tab1(col1: String, col2: String, col3: String, col4: Int)
 
   class Tabs1(tag: Tag) extends BaseT[Tab1](tag, "test_tab1") {
-    def * = (col1, col2, col3, col4) <> (Tab1.tupled, Tab1.unapply)
+    def * = (col1, col2, col3, col4) <> ((Tab1.apply _).tupled, Tab1.unapply)
   }
   val tabs1 = TableQuery(new Tabs1(_))
 
@@ -31,7 +31,7 @@ class PgInheritsSuite extends AnyFunSuite with PostgresContainer {
     val inherited = tabs1.baseTableRow
     def col5 = column[Long]("col5")
 
-    def * = (col1, col2, col3, col4, col5) <> (Tab2.tupled, Tab2.unapply)
+    def * = (col1, col2, col3, col4, col5) <> ((Tab2.apply _).tupled, Tab2.unapply)
   }
   val tabs2 = TableQuery(new Tabs2(_))
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgUpsertSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgUpsertSuite.scala
@@ -28,7 +28,7 @@ class PgUpsertSuite extends AnyFunSuite with PostgresContainer {
     def col1 = column[String]("col1")
     def col2 = column[Int]("col2")
 
-    def * = (id, col1, col2) <> (Bean.tupled, Bean.unapply)
+    def * = (id, col1, col2) <> ((Bean.apply _).tupled, Bean.unapply)
   }
   val UpsertTests = TableQuery[UpsertTestTable]
 
@@ -152,7 +152,7 @@ class PgUpsertSuite extends AnyFunSuite with PostgresContainer {
     def code = column[String]("code", O.PrimaryKey)
     def col2 = column[Int]("col2")
 
-    def * = (id.?, code, col2) <> (Bean1.tupled, Bean1.unapply)
+    def * = (id.?, code, col2) <> ((Bean1.apply _).tupled, Bean1.unapply)
   }
   val UpsertTests1 = TableQuery[UpsertTestTable1]
 
@@ -162,7 +162,7 @@ class PgUpsertSuite extends AnyFunSuite with PostgresContainer {
     def col2 = column[Int]("col2")
 
     def pk = primaryKey("pk_a1", code)
-    def * = (id.?, code, col2) <> (Bean1.tupled, Bean1.unapply)
+    def * = (id.?, code, col2) <> ((Bean1.apply _).tupled, Bean1.unapply)
   }
   val UpsertTests11 = TableQuery[UpsertTestTable11]
 
@@ -325,7 +325,7 @@ class PgUpsertSuite extends AnyFunSuite with PostgresContainer {
     def id = column[Long]("id", O.AutoInc)
     def code = column[String]("code", O.PrimaryKey)
 
-    def * = (id.?, code) <> (Bean12.tupled, Bean12.unapply)
+    def * = (id.?, code) <> ((Bean12.apply _).tupled, Bean12.unapply)
   }
   val UpsertTests12 = TableQuery[UpsertTestTable12]
 
@@ -412,7 +412,7 @@ class PgUpsertSuite extends AnyFunSuite with PostgresContainer {
     def start = column[Int]("start")
     def end = column[Int]("end")
 
-    def * = (id, start, end) <> (Bean2.tupled, Bean2.unapply)
+    def * = (id, start, end) <> ((Bean2.apply _).tupled, Bean2.unapply)
   }
   val UpsertTests2 = TableQuery[UpsertTestTable2]
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgWindowFuncCoreSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgWindowFuncCoreSuite.scala
@@ -25,7 +25,7 @@ class PgWindowFuncCoreSuite extends AnyFunSuite with PostgresContainer {
     def col3 = column[String]("COL3")
     def col4 = column[Int]("COL4")
 
-    def * = (col1, col2, col3, col4) <> (Tab.tupled, Tab.unapply)
+    def * = (col1, col2, col3, col4) <> ((Tab.apply _).tupled, Tab.unapply)
   }
   val tabs = TableQuery[Tabs]
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/PgWindowFuncSupportSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/PgWindowFuncSupportSuite.scala
@@ -21,7 +21,7 @@ class PgWindowFuncSupportSuite extends AnyFunSuite with PostgresContainer {
     def col3 = column[String]("COL3")
     def col4 = column[Int]("COL4")
 
-    def * = (col1, col2, col3, col4) <> (Tab.tupled, Tab.unapply)
+    def * = (col1, col2, col3, col4) <> ((Tab.apply _).tupled, Tab.unapply)
   }
   val tabs = TableQuery[Tabs]
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/package.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/package.scala
@@ -1,8 +1,8 @@
 package com.github.tminglei
 
 import java.util.concurrent.Executors
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 
 package object slickpg {
-  implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
+  implicit val testExecContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 }

--- a/core/src/test/scala/com/github/tminglei/slickpg/str/PgStringSupportSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/str/PgStringSupportSuite.scala
@@ -34,7 +34,7 @@ class PgStringSupportSuite extends AnyFunSuite with PostgresContainer {
     val str = column[String]("str")
     val strArr = column[Array[Byte]]("str_arr")
 
-    def * = (id, str, strArr) <> (StrBean.tupled, StrBean.unapply)
+    def * = (id, str, strArr) <> ((StrBean.apply _).tupled, StrBean.unapply)
   }
   val stringTestTable = TableQuery[StringTestTable]
 

--- a/core/src/test/scala/com/github/tminglei/slickpg/trgm/PgTrgmSupportSuite.scala
+++ b/core/src/test/scala/com/github/tminglei/slickpg/trgm/PgTrgmSupportSuite.scala
@@ -30,7 +30,7 @@ class PgTrgmSupportSuite extends AnyFunSuite with PostgresContainer {
     val id = column[Long]("id")
     val str = column[String]("str")
 
-    def * = (id, str) <> (StrBean.tupled, StrBean.unapply)
+    def * = (id, str) <> ((StrBean.apply _).tupled, StrBean.unapply)
   }
   val trgmTestTable = TableQuery[StringTestTable]
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgArraySupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgArraySupportSuite.scala
@@ -2,10 +2,11 @@ package com.github.tminglei.slickpg
 
 import java.sql.{Date, Time, Timestamp}
 import java.util.UUID
-
 import org.scalatest.funsuite.AnyFunSuite
-import slick.jdbc.GetResult
+import slick.ast.BaseTypedType
+import slick.jdbc.{GetResult, JdbcType, SetParameter}
 
+import scala.collection.mutable
 import scala.collection.mutable.Buffer
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -22,27 +23,27 @@ class PgArraySupportSuite extends AnyFunSuite with PostgresContainer {
 
     ///
     trait MyAPI extends ExtPostgresAPI with ArrayImplicits {
-      implicit val simpleOptStrListListMapper = new SimpleArrayJdbcType[String]("text")
+      implicit val simpleOptStrListListMapper: DriverJdbcType[List[Option[String]]] = new SimpleArrayJdbcType[String]("text")
         .mapTo[Option[String]](Option(_), _.orNull).to(_.toList)
-      implicit val simpleLongBufferTypeMapper = new SimpleArrayJdbcType[Long]("int8").to(_.toBuffer[Long], (v: Buffer[Long]) => v.toSeq)
-      implicit val simpleStrVectorTypeMapper = new SimpleArrayJdbcType[String]("text").to(_.toVector)
-      implicit val institutionListTypeWrapper =  new SimpleArrayJdbcType[Long]("int8")
+      implicit val simpleLongBufferTypeMapper: DriverJdbcType[mutable.Buffer[Long]] = new SimpleArrayJdbcType[Long]("int8").to(_.toBuffer[Long], (v: Buffer[Long]) => v.toSeq)
+      implicit val simpleStrVectorTypeMapper: DriverJdbcType[Vector[String]] = new SimpleArrayJdbcType[String]("text").to(_.toVector)
+      implicit val institutionListTypeWrapper: DriverJdbcType[List[Institution]] =  new SimpleArrayJdbcType[Long]("int8")
         .mapTo[Institution](new Institution(_), _.value).to(_.toList)
-      implicit val marketFinancialProductWrapper = new SimpleArrayJdbcType[String]("text")
+      implicit val marketFinancialProductWrapper: DriverJdbcType[List[MarketFinancialProduct]] = new SimpleArrayJdbcType[String]("text")
         .mapTo[MarketFinancialProduct](new MarketFinancialProduct(_), _.value).to(_.toList)
       ///
-      implicit val bigDecimalTypeWrapper = new SimpleArrayJdbcType[java.math.BigDecimal]("numeric")
+      implicit val bigDecimalTypeWrapper: DriverJdbcType[List[BigDecimal]] = new SimpleArrayJdbcType[java.math.BigDecimal]("numeric")
         .mapTo[scala.math.BigDecimal](javaBigDecimal => scala.math.BigDecimal(javaBigDecimal),
           scalaBigDecimal => scalaBigDecimal.bigDecimal).to(_.toList)
-      implicit val advancedStringListTypeMapper = new AdvancedArrayJdbcType[String]("text",
-        fromString(identity)(_).orNull, mkString(identity))
+      implicit val advancedStringListTypeMapper: AdvancedArrayJdbcType[String] = new AdvancedArrayJdbcType[String]("text",
+        fromString(identity)(_).orNull, mkString(identity[String]))
       ///
-      implicit val longlongWitness = ElemWitness.AnyWitness.asInstanceOf[ElemWitness[List[Long]]]
-      implicit val simpleLongLongListTypeMapper = new SimpleArrayJdbcType[List[Long]]("int8[]")
+      implicit val longlongWitness: ElemWitness[List[Long]] = ElemWitness.AnyWitness.asInstanceOf[ElemWitness[List[Long]]]
+      implicit val simpleLongLongListTypeMapper: DriverJdbcType[List[List[Long]]] = new SimpleArrayJdbcType[List[Long]]("int8[]")
         .to(_.asInstanceOf[Seq[Array[Any]]].toList.map(_.toList.asInstanceOf[List[Long]]))
 
-      implicit val institutionTypeWrapper = MappedJdbcType.base[Institution, Long](_.value, Institution)
-      implicit val marketFinancialProductTypeWrapper = MappedJdbcType.base[MarketFinancialProduct, String](_.value, MarketFinancialProduct)
+      implicit val institutionTypeWrapper: JdbcType[Institution] with BaseTypedType[Institution] = MappedJdbcType.base[Institution, Long](_.value, Institution)
+      implicit val marketFinancialProductTypeWrapper: JdbcType[MarketFinancialProduct] with BaseTypedType[MarketFinancialProduct] = MappedJdbcType.base[MarketFinancialProduct, String](_.value, MarketFinancialProduct)
     }
   }
   object MyPostgresProfile1 extends MyPostgresProfile1
@@ -84,7 +85,7 @@ class PgArraySupportSuite extends AnyFunSuite with PostgresContainer {
     def mktFinancialProducts = column[Option[List[MarketFinancialProduct]]]("mktFinancialProducts")
 
     def * = (id, str, intArr, longArr, longlongArr, shortArr, strList, optStrList, strArr, uuidArr,
-      bigDecimalArr, institutions, mktFinancialProducts) <> (ArrayBean.tupled, ArrayBean.unapply)
+      bigDecimalArr, institutions, mktFinancialProducts) <> ((ArrayBean.apply _).tupled, ArrayBean.unapply)
   }
   val ArrayTests = TableQuery[ArrayTestTable]
 
@@ -206,12 +207,12 @@ class PgArraySupportSuite extends AnyFunSuite with PostgresContainer {
       addNextArrayConverter((r) => r.nextArrayOption[Long]().map(_.map(Institution(_))))
     }
 
-    implicit val getInstitutionArray = mkGetResult(_.nextArray[Institution]())
-    implicit val getInstitutionArrayOption = mkGetResult(_.nextArrayOption[Institution]())
-    implicit val setInstitutionArray = mkArraySetParameter[Institution]("int8", v => String.valueOf(v.value))
-    implicit val setInstitutionArrayOption = mkArrayOptionSetParameter[Institution]("int8", v => String.valueOf(v.value))
+    implicit val getInstitutionArray: GetResult[Seq[Institution]] = mkGetResult(_.nextArray[Institution]())
+    implicit val getInstitutionArrayOption: GetResult[Option[Seq[Institution]]] = mkGetResult(_.nextArrayOption[Institution]())
+    implicit val setInstitutionArray: SetParameter[Seq[Institution]] = mkArraySetParameter[Institution]("int8", v => String.valueOf(v.value))
+    implicit val setInstitutionArrayOption: SetParameter[Option[Seq[Institution]]] = mkArrayOptionSetParameter[Institution]("int8", v => String.valueOf(v.value))
 
-    implicit val getArrarBean1Result = GetResult { r =>
+    implicit val getArrarBean1Result: GetResult[ArrayBean1] = GetResult { r =>
       ArrayBean1(r.nextLong(),
         r.<<[Array[Byte]],
         r.<<[Seq[UUID]].toList,

--- a/src/test/scala/com/github/tminglei/slickpg/PgCompositeSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgCompositeSupportSuite.scala
@@ -1,13 +1,10 @@
 package com.github.tminglei.slickpg
 
 import java.time.LocalDateTime
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
-
-import slick.jdbc.{GetResult, PositionedResult, PostgresProfile}
-
+import slick.jdbc.{GetResult, PositionedResult, PostgresProfile, SetParameter}
 import com.github.tminglei.slickpg.composite.Struct
 import org.postgresql.util.HStoreConverter
 import org.scalatest.funsuite.AnyFunSuite
@@ -67,16 +64,16 @@ object PgCompositeSupportSuite {
       utils.TypeConverters.register(mapToString)
       utils.TypeConverters.register(stringToMap)
 
-      implicit val composite1TypeMapper = createCompositeJdbcType[Composite1]("composite1")
-      implicit val composite2TypeMapper = createCompositeJdbcType[Composite2]("composite2")
-      implicit val composite3TypeMapper = createCompositeJdbcType[Composite3]("composite3")
-      implicit val composite4TypeMapper = createCompositeJdbcType[Composite4]("composite4")
-      implicit val c1TypeMapper = createCompositeJdbcType[C1]("c1")
-      implicit val c2TypeMapper = createCompositeJdbcType[C2]("c2")
+      implicit val composite1TypeMapper: GenericJdbcType[Composite1] = createCompositeJdbcType[Composite1]("composite1")
+      implicit val composite2TypeMapper: GenericJdbcType[Composite2] = createCompositeJdbcType[Composite2]("composite2")
+      implicit val composite3TypeMapper: GenericJdbcType[Composite3] = createCompositeJdbcType[Composite3]("composite3")
+      implicit val composite4TypeMapper: GenericJdbcType[Composite4] = createCompositeJdbcType[Composite4]("composite4")
+      implicit val c1TypeMapper: GenericJdbcType[C1] = createCompositeJdbcType[C1]("c1")
+      implicit val c2TypeMapper: GenericJdbcType[C2] = createCompositeJdbcType[C2]("c2")
 
-      implicit val composite1ArrayTypeMapper = createCompositeArrayJdbcType[Composite1]("composite1").to(_.toList)
-      implicit val composite2ArrayTypeMapper = createCompositeArrayJdbcType[Composite2]("composite2").to(_.toList)
-      implicit val composite3ArrayTypeMapper = createCompositeArrayJdbcType[Composite3]("composite3").to(_.toList)
+      implicit val composite1ArrayTypeMapper: DriverJdbcType[List[Composite1]] = createCompositeArrayJdbcType[Composite1]("composite1").to(_.toList)
+      implicit val composite2ArrayTypeMapper: DriverJdbcType[List[Composite2]] = createCompositeArrayJdbcType[Composite2]("composite2").to(_.toList)
+      implicit val composite3ArrayTypeMapper: DriverJdbcType[List[Composite3]] = createCompositeArrayJdbcType[Composite3]("composite3").to(_.toList)
     }
     override val api: API = new API {}
 
@@ -95,20 +92,20 @@ object PgCompositeSupportSuite {
         def nextComposite3() = nextComposite[Composite3](r)
       }
 
-      implicit val composite1SetParameter = createCompositeSetParameter[Composite1]("composite1")
-      implicit val composite1OptSetParameter = createCompositeOptionSetParameter[Composite1]("composite1")
-      implicit val composite1ArraySetParameter = createCompositeArraySetParameter[Composite1]("composite1")
-      implicit val composite1ArrayOptSetParameter = createCompositeOptionArraySetParameter[Composite1]("composite1")
+      implicit val composite1SetParameter: SetParameter[Composite1] = createCompositeSetParameter[Composite1]("composite1")
+      implicit val composite1OptSetParameter: SetParameter[Option[Composite1]] = createCompositeOptionSetParameter[Composite1]("composite1")
+      implicit val composite1ArraySetParameter: SetParameter[Seq[Composite1]] = createCompositeArraySetParameter[Composite1]("composite1")
+      implicit val composite1ArrayOptSetParameter: SetParameter[Option[Seq[Composite1]]] = createCompositeOptionArraySetParameter[Composite1]("composite1")
 
-      implicit val composite2SetParameter = createCompositeSetParameter[Composite2]("composite2")
-      implicit val composite2OptSetParameter = createCompositeOptionSetParameter[Composite2]("composite2")
-      implicit val composite2ArraySetParameter = createCompositeArraySetParameter[Composite2]("composite2")
-      implicit val composite2ArrayOptSetParameter = createCompositeOptionArraySetParameter[Composite2]("composite2")
+      implicit val composite2SetParameter: SetParameter[Composite2] = createCompositeSetParameter[Composite2]("composite2")
+      implicit val composite2OptSetParameter: SetParameter[Option[Composite2]] = createCompositeOptionSetParameter[Composite2]("composite2")
+      implicit val composite2ArraySetParameter: SetParameter[Seq[Composite2]] = createCompositeArraySetParameter[Composite2]("composite2")
+      implicit val composite2ArrayOptSetParameter: SetParameter[Option[Seq[Composite2]]] = createCompositeOptionArraySetParameter[Composite2]("composite2")
 
-      implicit val composite3SetParameter = createCompositeSetParameter[Composite3]("composite3")
-      implicit val composite3OptSetParameter = createCompositeOptionSetParameter[Composite3]("composite3")
-      implicit val composite3ArraySetParameter = createCompositeArraySetParameter[Composite3]("composite3")
-      implicit val composite3ArrayOptSetParameter = createCompositeOptionArraySetParameter[Composite3]("composite3")
+      implicit val composite3SetParameter: SetParameter[Composite3] = createCompositeSetParameter[Composite3]("composite3")
+      implicit val composite3OptSetParameter: SetParameter[Option[Composite3]] = createCompositeOptionSetParameter[Composite3]("composite3")
+      implicit val composite3ArraySetParameter: SetParameter[Seq[Composite3]] = createCompositeArraySetParameter[Composite3]("composite3")
+      implicit val composite3ArrayOptSetParameter: SetParameter[Option[Seq[Composite3]]] = createCompositeOptionArraySetParameter[Composite3]("composite3")
     }
   }
   object MyPostgresProfile1 extends MyPostgresProfile1
@@ -146,7 +143,7 @@ class PgCompositeSupportSuite extends AnyFunSuite with PostgresContainer {
     def id = column[Long]("id")
     def comps = column[List[Composite2]]("comps", O.Default(Nil))
 
-    def * = (id,comps) <> (TestBean.tupled, TestBean.unapply)
+    def * = (id,comps) <> ((TestBean.apply _).tupled, TestBean.unapply)
   }
   val CompositeTests = TableQuery(new TestTable(_))
 
@@ -154,7 +151,7 @@ class PgCompositeSupportSuite extends AnyFunSuite with PostgresContainer {
     def id = column[Long]("id")
     def comps = column[List[Composite3]]("comps")
 
-    def * = (id,comps) <> (TestBean1.tupled, TestBean1.unapply)
+    def * = (id,comps) <> ((TestBean1.apply _).tupled, TestBean1.unapply)
   }
   val CompositeTests1 = TableQuery(new TestTable1(_))
 
@@ -163,7 +160,7 @@ class PgCompositeSupportSuite extends AnyFunSuite with PostgresContainer {
     def comps = column[Composite1]("comp")
     def c2 = column[C2]("c2")
 
-    def * = (id,comps,c2) <> (TestBean2.tupled, TestBean2.unapply)
+    def * = (id,comps,c2) <> ((TestBean2.apply _).tupled, TestBean2.unapply)
   }
   val CompositeTests2 = TableQuery(new TestTable2(_))
 
@@ -171,7 +168,7 @@ class PgCompositeSupportSuite extends AnyFunSuite with PostgresContainer {
     def id = column[Long]("id")
     def comps = column[Option[Composite4]]("comp")
 
-    def * = (id, comps) <> (TestBean3.tupled, TestBean3.unapply)
+    def * = (id, comps) <> ((TestBean3.apply _).tupled, TestBean3.unapply)
   }
   val CompositeTests3 = TableQuery(new TestTable3(_))
 
@@ -284,8 +281,8 @@ class PgCompositeSupportSuite extends AnyFunSuite with PostgresContainer {
   test("Composite type Plain SQL support") {
     import MyPostgresProfile1.plainImplicits._
 
-    implicit val getTestBeanResult = GetResult(r => TestBean(r.nextLong(), r.nextArray[Composite2]().toList))
-    implicit val getTestBean1Result = GetResult(r => TestBean1(r.nextLong(), r.nextArray[Composite3]().toList))
+    implicit val getTestBeanResult: GetResult[TestBean] = GetResult(r => TestBean(r.nextLong(), r.nextArray[Composite2]().toList))
+    implicit val getTestBean1Result: GetResult[TestBean1] = GetResult(r => TestBean1(r.nextLong(), r.nextArray[Composite3]().toList))
 
     Await.result(db.run(DBIO.seq(
       sqlu"create type composite1 as (id int8, txt text, date timestamp, ts_range tsrange)",

--- a/src/test/scala/com/github/tminglei/slickpg/PgDate2SupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgDate2SupportSuite.scala
@@ -43,7 +43,7 @@ class PgDate2SupportSuite extends AnyFunSuite with PostgresContainer {
     def zone = column[ZoneId]("zone")
 
     def * = (id, date, time, dateTime, dateTimeOffset, dateTimeTz, instant, duration, period, zone) <>
-            (DatetimeBean.tupled, DatetimeBean.unapply)
+            ((DatetimeBean.apply _).tupled, DatetimeBean.unapply)
   }
   val Datetimes = TableQuery[DatetimeTable]
 
@@ -289,7 +289,7 @@ class PgDate2SupportSuite extends AnyFunSuite with PostgresContainer {
 
       def * = (id, date, time, dateTime, dateTimeOffset,
                dateTimeTz, instant, duration, period, zone) <>
-        (DatetimeOptionBean.tupled, DatetimeOptionBean.unapply)
+        ((DatetimeOptionBean.apply _).tupled, DatetimeOptionBean.unapply)
     }
     val DatetimesOption = TableQuery[DatetimeOptionTable]
 
@@ -360,7 +360,7 @@ class PgDate2SupportSuite extends AnyFunSuite with PostgresContainer {
   test("Java8 date Plain SQL support") {
     import MyPostgresProfile.plainAPI._
 
-    implicit val getDateBean = GetResult(r => DatetimeBean(
+    implicit val getDateBean: GetResult[DatetimeBean] = GetResult(r => DatetimeBean(
       r.nextLong(), r.nextLocalDate(), r.nextLocalTime(), r.nextLocalDateTime(), r.nextOffsetDateTime(), r.nextZonedDateTime(),
       r.nextInstant(), r.nextDuration(), r.nextPeriod(), r.nextZoneId()))
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgDateSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgDateSupportSuite.scala
@@ -51,7 +51,7 @@ class PgDateSupportSuite extends AnyFunSuite with PostgresContainer {
     def timestamptz = column[Calendar]("timestamptz")
     def interval = column[Interval]("interval")
 
-    def * = (id, date, time, timestamp, timestamptz, interval) <> (DatetimeBean.tupled, DatetimeBean.unapply)
+    def * = (id, date, time, timestamp, timestamptz, interval) <> ((DatetimeBean.apply _).tupled, DatetimeBean.unapply)
   }
   val Datetimes = TableQuery[DatetimeTable]
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgEnumSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgEnumSupportSuite.scala
@@ -4,9 +4,7 @@ import scala.collection.compat._
 import scala.collection.compat.immutable.LazyList
 import scala.concurrent.Await
 import scala.concurrent.duration._
-
-import slick.jdbc.PostgresProfile
-
+import slick.jdbc.{JdbcType, PostgresProfile}
 import org.scalatest.funsuite.AnyFunSuite
 
 
@@ -57,30 +55,30 @@ class PgEnumSupportSuite extends AnyFunSuite with PostgresContainer {
 
     ///
     trait API extends JdbcAPI {
-      implicit val weekDayTypeMapper = createEnumJdbcType("WeekDay", WeekDays)
-      implicit val weekDayListTypeMapper = createEnumListJdbcType("weekDay", WeekDays)
-      implicit val rainbowTypeMapper = createEnumJdbcType("Rainbow", Rainbows, true)
-      implicit val rainbowListTypeMapper = createEnumListJdbcType("Rainbow", Rainbows, true)
+      implicit val weekDayTypeMapper: JdbcType[WeekDays.Value] = createEnumJdbcType[WeekDays.type]("WeekDay", WeekDays)
+      implicit val weekDayListTypeMapper: JdbcType[List[WeekDays.Value]] = createEnumListJdbcType[WeekDays.type]("weekDay", WeekDays)
+      implicit val rainbowTypeMapper: JdbcType[Rainbows.Value] = createEnumJdbcType[Rainbows.type]("Rainbow", Rainbows, true)
+      implicit val rainbowListTypeMapper: JdbcType[List[Rainbows.Value]] = createEnumListJdbcType[Rainbows.type]("Rainbow", Rainbows, true)
 
-      implicit val weekDayColumnExtensionMethodsBuilder = createEnumColumnExtensionMethodsBuilder(WeekDays)
-      implicit val weekDayOptionColumnExtensionMethodsBuilder = createEnumOptionColumnExtensionMethodsBuilder(WeekDays)
-      implicit val rainbowColumnExtensionMethodsBuilder = createEnumColumnExtensionMethodsBuilder(Rainbows)
-      implicit val rainbowOptionColumnExtensionMethodsBuilder = createEnumOptionColumnExtensionMethodsBuilder(Rainbows)
+      implicit val weekDayColumnExtensionMethodsBuilder: api.Rep[WeekDays.Value] => EnumColumnExtensionMethods[WeekDays.Value, WeekDays.Value] = createEnumColumnExtensionMethodsBuilder[WeekDays.type](WeekDays)
+      implicit val weekDayOptionColumnExtensionMethodsBuilder: api.Rep[Option[WeekDays.Value]] => EnumColumnExtensionMethods[WeekDays.Value, Option[WeekDays.Value]] = createEnumOptionColumnExtensionMethodsBuilder[WeekDays.type](WeekDays)
+      implicit val rainbowColumnExtensionMethodsBuilder: api.Rep[Rainbows.Value] => EnumColumnExtensionMethods[Rainbows.Value, Rainbows.Value] = createEnumColumnExtensionMethodsBuilder[Rainbows.type](Rainbows)
+      implicit val rainbowOptionColumnExtensionMethodsBuilder: api.Rep[Option[Rainbows.Value]] => EnumColumnExtensionMethods[Rainbows.Value, Option[Rainbows.Value]] = createEnumOptionColumnExtensionMethodsBuilder[Rainbows.type](Rainbows)
 
       /// custom types of java enums and algebraic data type (ADT)
-      implicit val currencyTypeMapper = createEnumJdbcType[Currency]("Currency", _.toString, Currency.values.get(_).get, quoteName = false)
-      implicit val currencyTypeListMapper = createEnumListJdbcType[Currency]("Currency", _.toString, Currency.values.get(_).get, quoteName = false)
-      implicit val languagesTypeMapper = createEnumJdbcType[Languages]("Languages", _.name(), Languages.valueOf, quoteName = true)
-      implicit val languagesTypeListMapper = createEnumListJdbcType[Languages]("Languages", _.name(), Languages.valueOf, quoteName = true)
-      implicit val genderTypeMapper = createEnumJdbcType[Gender]("Gender", _.repr, Gender.fromString, quoteName = false)
-      implicit val genderTypeListMapper = createEnumListJdbcType[Gender]("Gender", _.repr, Gender.fromString, quoteName = false)
+      implicit val currencyTypeMapper: JdbcType[Currency] = createEnumJdbcType[Currency]("Currency", _.toString, Currency.values.get(_).get, quoteName = false)
+      implicit val currencyTypeListMapper: JdbcType[List[Currency]] = createEnumListJdbcType[Currency]("Currency", _.toString, Currency.values.get(_).get, quoteName = false)
+      implicit val languagesTypeMapper: JdbcType[Languages] = createEnumJdbcType[Languages]("Languages", _.name(), Languages.valueOf, quoteName = true)
+      implicit val languagesTypeListMapper: JdbcType[List[Languages]] = createEnumListJdbcType[Languages]("Languages", _.name(), Languages.valueOf, quoteName = true)
+      implicit val genderTypeMapper: JdbcType[Gender] = createEnumJdbcType[Gender]("Gender", _.repr, Gender.fromString, quoteName = false)
+      implicit val genderTypeListMapper: JdbcType[List[Gender]] = createEnumListJdbcType[Gender]("Gender", _.repr, Gender.fromString, quoteName = false)
 
-      implicit val currencyColumnExtensionMethodsBuilder = createEnumColumnExtensionMethodsBuilder[Currency]
-      implicit val currencyOptionColumnExtensionMethodsBuilder = createEnumOptionColumnExtensionMethodsBuilder[Currency]
-      implicit val languagesColumnExtensionMethodsBuilder = createEnumColumnExtensionMethodsBuilder[Languages]
-      implicit val languagesOptionColumnExtensionMethodsBuilder = createEnumOptionColumnExtensionMethodsBuilder[Languages]
-      implicit val genderColumnExtensionMethodsBuilder = createEnumColumnExtensionMethodsBuilder[Gender]
-      implicit val genderOptionColumnExtensionMethodsBuilder = createEnumOptionColumnExtensionMethodsBuilder[Gender]
+      implicit val currencyColumnExtensionMethodsBuilder: api.Rep[Currency] => EnumColumnExtensionMethods[Currency, Currency] = createEnumColumnExtensionMethodsBuilder[Currency]
+      implicit val currencyOptionColumnExtensionMethodsBuilder: api.Rep[Option[Currency]] => EnumColumnExtensionMethods[Currency, Option[Currency]] = createEnumOptionColumnExtensionMethodsBuilder[Currency]
+      implicit val languagesColumnExtensionMethodsBuilder: api.Rep[Languages] => EnumColumnExtensionMethods[Languages, Languages] = createEnumColumnExtensionMethodsBuilder[Languages]
+      implicit val languagesOptionColumnExtensionMethodsBuilder: api.Rep[Option[Languages]] => EnumColumnExtensionMethods[Languages, Option[Languages]] = createEnumOptionColumnExtensionMethodsBuilder[Languages]
+      implicit val genderColumnExtensionMethodsBuilder: api.Rep[Gender] => EnumColumnExtensionMethods[Gender, Gender] = createEnumColumnExtensionMethodsBuilder[Gender]
+      implicit val genderOptionColumnExtensionMethodsBuilder: api.Rep[Option[Gender]] => EnumColumnExtensionMethods[Gender, Option[Gender]] = createEnumOptionColumnExtensionMethodsBuilder[Gender]
     }
   }
   object MyPostgresProfile1 extends MyPostgresProfile1
@@ -104,7 +102,7 @@ class PgEnumSupportSuite extends AnyFunSuite with PostgresContainer {
     def weekdays = column[List[WeekDay]]("weekdays")
     def rainbows = column[List[Rainbow]]("rainbows")
 
-    def * = (id, weekday, rainbow, weekdays, rainbows) <> (TestEnumBean.tupled, TestEnumBean.unapply)
+    def * = (id, weekday, rainbow, weekdays, rainbows) <> ((TestEnumBean.apply _).tupled, TestEnumBean.unapply)
   }
   val TestEnums = TableQuery(new TestEnumTable(_))
 
@@ -125,7 +123,7 @@ class PgEnumSupportSuite extends AnyFunSuite with PostgresContainer {
     def currencies = column[List[Currency]]("currencies")
     def languages = column[List[Languages]]("languages")
 
-    def * = (id, currency, language, gender, currencies, languages) <> (TestEnumBean1.tupled, TestEnumBean1.unapply)
+    def * = (id, currency, language, gender, currencies, languages) <> ((TestEnumBean1.apply _).tupled, TestEnumBean1.unapply)
   }
   val TestEnums1 = TableQuery(new TestEnumTable1(_))
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgHStoreSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgHStoreSupportSuite.scala
@@ -17,7 +17,7 @@ class PgHStoreSupportSuite extends AnyFunSuite with PostgresContainer {
     def id = column[Long]("id", O.AutoInc, O.PrimaryKey)
     def hstore = column[Map[String, String]]("hstoreMap", O.Default(Map.empty))
 
-    def * = (id, hstore) <> (MapBean.tupled, MapBean.unapply)
+    def * = (id, hstore) <> ((MapBean.apply _).tupled, MapBean.unapply)
   }
   val HStoreTests = TableQuery[HStoreTestTable]
 
@@ -107,7 +107,7 @@ class PgHStoreSupportSuite extends AnyFunSuite with PostgresContainer {
   test("Hstore Plain SQL support") {
     import MyPostgresProfile.plainAPI._
 
-    implicit val getMapBeanResult = GetResult(r => MapBean(r.nextLong(), r.nextHStore()))
+    implicit val getMapBeanResult: GetResult[MapBean] = GetResult(r => MapBean(r.nextLong(), r.nextHStore()))
 
     val b = MapBean(34L, Map("a"->"val1", "b"->"val3", "c"->"321"))
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgJsonSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgJsonSupportSuite.scala
@@ -18,7 +18,7 @@ class PgJsonSupportSuite extends AnyFunSuite with PostgresContainer {
     def id = column[Long]("id", O.AutoInc, O.PrimaryKey)
     def json = column[JsonString]("json", O.Default(JsonString(""" {"a":"v1","b":2} """)))
 
-    def * = (id, json) <> (JsonBean.tupled, JsonBean.unapply)
+    def * = (id, json) <> ((JsonBean.apply _).tupled, JsonBean.unapply)
   }
   val JsonTests = TableQuery[JsonTestTable]
 
@@ -148,7 +148,7 @@ class PgJsonSupportSuite extends AnyFunSuite with PostgresContainer {
   test("Json Plain SQL support") {
     import MyPostgresProfile.plainAPI._
 
-    implicit val getJsonBeanResult = GetResult(r => JsonBean(r.nextLong(), r.nextJson()))
+    implicit val getJsonBeanResult: GetResult[JsonBean] = GetResult(r => JsonBean(r.nextLong(), r.nextJson()))
 
     val b = JsonBean(34L, JsonString(""" { "a":101, "b":"aaa", "c":[3,4,5,9] } """))
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgLTreeSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgLTreeSupportSuite.scala
@@ -19,7 +19,7 @@ class PgLTreeSupportSuite extends AnyFunSuite with PostgresContainer {
     def path = column[LTree]("path")
     def treeArr = column[List[LTree]]("tree_arr")
 
-    def * = (id, path, treeArr) <> (LTreeBean.tupled, LTreeBean.unapply)
+    def * = (id, path, treeArr) <> ((LTreeBean.apply _).tupled, LTreeBean.unapply)
   }
   val LTreeTests = TableQuery[LTreeTestTable]
 
@@ -166,7 +166,7 @@ class PgLTreeSupportSuite extends AnyFunSuite with PostgresContainer {
   test("Ltree Plain SQL support") {
     import MyPostgresProfile.plainAPI._
 
-    implicit val getLTreeBeanResult = GetResult(r => LTreeBean(r.nextLong(), r.nextLTree(), r.nextArray[LTree]().toList))
+    implicit val getLTreeBeanResult: GetResult[LTreeBean] = GetResult(r => LTreeBean(r.nextLong(), r.nextLTree(), r.nextArray[LTree]().toList))
 
     val b = LTreeBean(100L, LTree("Top"), List(LTree("Top.Science"), LTree("Top.Collections")))
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgNetSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgNetSupportSuite.scala
@@ -19,7 +19,7 @@ class PgNetSupportSuite extends AnyFunSuite with PostgresContainer {
     def inet = column[InetString]("inet")
     def mac = column[Option[MacAddrString]]("mac")
 
-    def * = (id, inet, mac) <> (NetBean.tupled, NetBean.unapply)
+    def * = (id, inet, mac) <> ((NetBean.apply _).tupled, NetBean.unapply)
   }
   val NetTests = TableQuery[NetTestTable]
 
@@ -180,7 +180,7 @@ class PgNetSupportSuite extends AnyFunSuite with PostgresContainer {
   test("net Plain SQL support") {
     import MyPostgresProfile.plainAPI._
 
-    implicit val getNetBeanResult = GetResult(r => NetBean(r.nextLong(), r.nextIPAddr(), r.nextMacAddrOption()))
+    implicit val getNetBeanResult: GetResult[NetBean] = GetResult(r => NetBean(r.nextLong(), r.nextIPAddr(), r.nextMacAddrOption()))
 
     val b = NetBean(34L, InetString("10.1.0.0/16"), Some(MacAddrString("12:34:56:78:90:ab")))
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgRangeSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgRangeSupportSuite.scala
@@ -39,7 +39,7 @@ class PgRangeSupportSuite extends AnyFunSuite with PostgresContainer {
     def odtRange = column[Option[Range[OffsetDateTime]]]("odt_range")
     def ldRange = column[Option[Range[LocalDate]]]("ld_range")
 
-    def * = (id, intRange, floatRange, tsRange, ldtRange, odtRange, ldRange) <> (RangeBean.tupled, RangeBean.unapply)
+    def * = (id, intRange, floatRange, tsRange, ldtRange, odtRange, ldRange) <> ((RangeBean.apply _).tupled, RangeBean.unapply)
   }
   val RangeTests = TableQuery[RangeTestTable]
 
@@ -159,7 +159,7 @@ class PgRangeSupportSuite extends AnyFunSuite with PostgresContainer {
   test("Range Plain SQL support") {
     import MyPostgresProfile.plainAPI._
 
-    implicit val getRangeBeanResult = GetResult(r =>
+    implicit val getRangeBeanResult: GetResult[RangeBean] = GetResult(r =>
       RangeBean(r.nextLong(), r.nextIntRange(), r.nextFloatRange(), r.nextTimestampRangeOption(),
         r.nextLocalDateTimeRangeOption(), r.nextOffsetDateTimeRangeOption(), r.nextLocalDateRangeOption()))
 

--- a/src/test/scala/com/github/tminglei/slickpg/PgSearchSupportSuite.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/PgSearchSupportSuite.scala
@@ -23,7 +23,7 @@ class PgSearchSupportSuite extends AnyFunSuite with PostgresContainer {
     def search = column[TsVector]("search")
     def comment = column[String]("comment")
 
-    def * = (id, text, search, comment) <> (TestBean.tupled, TestBean.unapply)
+    def * = (id, text, search, comment) <> ((TestBean.apply _).tupled, TestBean.unapply)
   }
   val Tests = TableQuery[TestTable]
 
@@ -160,7 +160,7 @@ class PgSearchSupportSuite extends AnyFunSuite with PostgresContainer {
 
     case class SearchBean(id: Long, tVec: TsVector, tQ: TsQuery)
 
-    implicit val getSearchBeanResult = GetResult(r => SearchBean(r.nextLong(), r.nextTsVector(), r.nextTsQuery()))
+    implicit val getSearchBeanResult: GetResult[SearchBean] = GetResult(r => SearchBean(r.nextLong(), r.nextTsVector(), r.nextTsQuery()))
 
     val b = SearchBean(101L, TsVector("'ate' 'cat' 'fat' 'rat'"), TsQuery("'rat'"))
 

--- a/src/test/scala/com/github/tminglei/slickpg/package.scala
+++ b/src/test/scala/com/github/tminglei/slickpg/package.scala
@@ -1,8 +1,8 @@
 package com.github.tminglei
 
 import java.util.concurrent.Executors
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 
 package object slickpg {
-  implicit val testExecContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
+  implicit val testExecContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
 }


### PR DESCRIPTION
Adds some implicit types, and some modified syntax around some 'tupled' expressions, to reduce the number of errors we see when attempting to compile with scala 3. Obviously without a replacement for the typetag code this doesn't _actually_ compile, but when stubbing those out for now it gets us a little closer